### PR TITLE
refactor: centralize layout style helpers

### DIFF
--- a/components/layout/classic-header.tsx
+++ b/components/layout/classic-header.tsx
@@ -13,7 +13,7 @@ import {
 import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useAuth } from "@/providers/auth-provider";
-import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 
@@ -26,81 +26,31 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
   const { language, setLanguage, t, direction } = useI18n();
   const { user } = useAuth();
   const {
-    headerStyle,
-    spacingSize,
-    borderRadius,
-    animationLevel,
-    shadowIntensity,
-  } = useSettings();
+    getSpacingClass,
+    getHeaderStyleClass,
+    getShadowClass,
+    getAnimationClass,
+    getBorderRadiusClass,
+  } = useLayoutStyles();
 
-  const getSpacingClass = () => {
-    switch (spacingSize) {
-      case "compact":
-        return "px-4 py-2";
-      case "comfortable":
-        return "px-10 py-6";
-      case "spacious":
-        return "px-12 py-8";
-      default:
-        return "px-8 py-4";
-    }
-  };
+  const animationClass = getAnimationClass();
 
-  const getHeaderStyleClass = () => {
-    switch (headerStyle) {
-      case "compact":
-        return "h-14 bg-background/95 border-b";
-      case "elevated":
-        return "bg-gradient-to-r from-background via-background/98 to-background border-b-2 border-border/80 shadow-xl shadow-primary/10";
-      case "transparent":
-        return "bg-transparent backdrop-blur-xl border-b border-border/30";
-      default:
-        return "bg-gradient-to-r from-background via-background/95 to-background border-b-2 border-border/80 shadow-lg shadow-primary/5 backdrop-blur-sm";
-    }
-  };
-
-  const getShadowClass = () => {
-    switch (shadowIntensity) {
-      case "none":
-        return "";
-      case "subtle":
-        return "shadow-sm";
-      case "strong":
-        return "shadow-2xl";
-      default:
-        return "shadow-lg";
-    }
-  };
-
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-200";
-    if (animationLevel === "moderate") return "transition-all duration-300";
-    return "transition-all duration-500 ease-in-out";
-  };
-
-  const getBorderRadiusClass = () => {
-    switch (borderRadius) {
-      case "none":
-        return "rounded-none";
-      case "small":
-        return "rounded-sm";
-      case "large":
-        return "rounded-lg";
-      case "full":
-        return "rounded-full";
-      default:
-        return "rounded-xl";
-    }
-  };
+  const headerClass = getHeaderStyleClass({
+    compact: "h-14 bg-background/95 border-b",
+    elevated:
+      "bg-gradient-to-r from-background via-background/98 to-background border-b-2 border-border/80 shadow-xl shadow-primary/10",
+    transparent: "bg-transparent backdrop-blur-xl border-b border-border/30",
+    default:
+      "bg-gradient-to-r from-background via-background/95 to-background border-b-2 border-border/80 shadow-lg shadow-primary/5 backdrop-blur-sm",
+  });
 
   return (
     <header
       className={cn(
         "sticky top-0 z-40",
-        getHeaderStyleClass(),
+        headerClass,
         getShadowClass(),
-        getAnimationClass()
+        animationClass
       )}
     >
       <div
@@ -114,7 +64,7 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
             className={cn(
               "lg:hidden hover:bg-primary/10 hover:text-primary",
               getBorderRadiusClass(),
-              getAnimationClass(),
+              animationClass,
               "shadow-md hover:shadow-lg hover:scale-105"
             )}
             onClick={onMenuClick}
@@ -133,7 +83,7 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
               className={cn(
                 "pl-10 rtl:pl-4 rtl:pr-10 w-64 bg-muted/50 border-0 focus:bg-background",
                 getBorderRadiusClass(),
-                getAnimationClass(),
+                animationClass,
                 "shadow-sm focus:shadow-md hover:shadow-md"
               )}
             />
@@ -148,7 +98,7 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
                 className={cn(
                   "hover:bg-primary/10 hover:text-primary",
                   getBorderRadiusClass(),
-                  getAnimationClass(),
+                  animationClass,
                   "shadow-md hover:shadow-lg hover:scale-105"
                 )}
               >
@@ -183,7 +133,7 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
                 className={cn(
                   "hover:bg-primary/10 hover:text-primary",
                   getBorderRadiusClass(),
-                  getAnimationClass(),
+                  animationClass,
                   "shadow-md hover:shadow-lg hover:scale-105"
                 )}
               >

--- a/components/layout/classic-layout.tsx
+++ b/components/layout/classic-layout.tsx
@@ -6,6 +6,7 @@ import { ClassicHeader } from "./classic-header"
 import { useI18n } from "@/providers/i18n-provider"
 import { useSettings } from "@/providers/settings-provider"
 import { cn } from "@/lib/utils"
+import { useLayoutStyles } from "./use-layout-styles"
 
 interface ClassicLayoutProps {
   children: React.ReactNode
@@ -16,19 +17,27 @@ interface ClassicLayoutProps {
 export function ClassicLayout({ children, sidebarOpen, onSidebarOpenChange }: ClassicLayoutProps) {
   const { direction } = useI18n()
   const settings = useSettings()
-
-  const getSpacingClass = () => {
-    switch (settings.spacingSize) {
-      case "compact":
-        return "p-4"
-      case "comfortable":
-        return "p-10"
-      case "spacious":
-        return "p-12"
-      default:
-        return "p-8"
-    }
-  }
+  const {
+    getSpacingClass,
+    getAnimationClass,
+    getBorderRadiusClass,
+    getShadowClass,
+  } = useLayoutStyles()
+  const spacingClass = getSpacingClass({
+    compact: "p-4",
+    comfortable: "p-10",
+    spacious: "p-12",
+    default: "p-8",
+  })
+  const animationClass = getAnimationClass({
+    high: "transition-all duration-500 ease-in-out",
+  })
+  const borderRadiusClass = getBorderRadiusClass()
+  const shadowClass = getShadowClass({
+    moderate: "shadow-md",
+    strong: "shadow-lg",
+    default: "shadow-md",
+  })
 
   const getFontSizeClass = () => {
     switch (settings.fontSize) {
@@ -41,40 +50,7 @@ export function ClassicLayout({ children, sidebarOpen, onSidebarOpenChange }: Cl
     }
   }
 
-  const getAnimationClass = () => {
-    if (settings.animationLevel === "none") return ""
-    if (settings.animationLevel === "minimal") return "transition-colors duration-200"
-    if (settings.animationLevel === "moderate") return "transition-all duration-300"
-    return "transition-all duration-500 ease-in-out"
-  }
-
-  const getBorderRadiusClass = () => {
-    switch (settings.borderRadius) {
-      case "none":
-        return "rounded-none"
-      case "small":
-        return "rounded-sm"
-      case "large":
-        return "rounded-lg"
-      case "full":
-        return "rounded-full"
-      default:
-        return "rounded-md"
-    }
-  }
-
-  const getShadowClass = () => {
-    switch (settings.shadowIntensity) {
-      case "none":
-        return ""
-      case "subtle":
-        return "shadow-sm"
-      case "strong":
-        return "shadow-lg"
-      default:
-        return "shadow-md"
-    }
-  }
+  
 
   return (
     <div 
@@ -95,19 +71,19 @@ export function ClassicLayout({ children, sidebarOpen, onSidebarOpenChange }: Cl
 
       <div 
         className={cn(
-          getAnimationClass(),
+          animationClass,
           direction === "rtl" ? "lg:mr-80" : "lg:ml-80"
         )}
       >
         {/* Classic header - simpler with fewer elements */}
         <ClassicHeader onMenuClick={() => onSidebarOpenChange(true)} />
 
-        <main className={cn(getSpacingClass())}>
+        <main className={cn(spacingClass)}>
           <div 
             className={cn(
               "animate-fade-in",
-              getBorderRadiusClass(),
-              getShadowClass(),
+              borderRadiusClass,
+              shadowClass,
               settings.cardStyle === "bordered" && "border border-border",
               settings.cardStyle === "elevated" && "bg-card shadow-lg",
               settings.cardStyle === "glass" && "bg-background/80 backdrop-blur-sm"
@@ -128,7 +104,7 @@ export function ClassicLayout({ children, sidebarOpen, onSidebarOpenChange }: Cl
         <div
           className={cn(
             "fixed inset-0 bg-black/50 z-40 lg:hidden backdrop-blur-sm",
-            getAnimationClass()
+            animationClass
           )}
           onClick={() => onSidebarOpenChange(false)}
         />

--- a/components/layout/classic-sidebar.tsx
+++ b/components/layout/classic-sidebar.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { useI18n } from "@/providers/i18n-provider";
 import { useAuth } from "@/providers/auth-provider";
 import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { cn } from "@/lib/utils";
 import {
   Collapsible,
@@ -32,14 +33,22 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
   const pathname = usePathname();
   const { t, direction } = useI18n();
   const { user } = useAuth();
+  const { colorTheme } = useSettings();
   const {
-    colorTheme,
-    sidebarStyle,
-    spacingSize,
-    borderRadius,
-    animationLevel,
-    shadowIntensity,
-  } = useSettings();
+    getSpacingClass,
+    getBorderRadiusClass,
+    getShadowClass,
+    getAnimationClass,
+  } = useLayoutStyles();
+  const borderRadiusClass = getBorderRadiusClass({
+    large: "rounded-2xl",
+    full: "rounded-3xl",
+    default: "rounded-xl",
+  });
+  const animationClass = getAnimationClass({
+    high: "transition-all duration-500 ease-in-out",
+  });
+  const shadowClass = getShadowClass();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
 
   // Get navigation items with translations and filter out profile, settings, logout
@@ -55,53 +64,7 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
     );
   };
 
-  const getSpacingClass = () => {
-    switch (spacingSize) {
-      case "compact":
-        return "p-2 space-y-1";
-      case "comfortable":
-        return "p-8 space-y-6";
-      case "spacious":
-        return "p-12 space-y-8";
-      default:
-        return "p-6 space-y-4";
-    }
-  };
-
-  const getBorderRadiusClass = () => {
-    switch (borderRadius) {
-      case "none":
-        return "rounded-none";
-      case "small":
-        return "rounded-sm";
-      case "large":
-        return "rounded-2xl";
-      case "full":
-        return "rounded-3xl";
-      default:
-        return "rounded-xl";
-    }
-  };
-
-  const getShadowClass = () => {
-    switch (shadowIntensity) {
-      case "none":
-        return "";
-      case "subtle":
-        return "shadow-sm";
-      case "strong":
-        return "shadow-2xl";
-      default:
-        return "shadow-lg";
-    }
-  };
-
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-200";
-    if (animationLevel === "moderate") return "transition-all duration-300";
-    return "transition-all duration-500 ease-in-out";
-  };
+  
 
   const renderNavigationItem = (item: NavigationItem, level = 0) => {
     const isActive = isNavigationItemActive(item, pathname);
@@ -121,8 +84,8 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
             <div
               className={cn(
                 "group flex items-center justify-between w-full px-6 py-4 text-base font-medium cursor-pointer",
-                getBorderRadiusClass(),
-                getAnimationClass(),
+                borderRadiusClass,
+                animationClass,
                 item.disabled && "opacity-50 cursor-not-allowed",
                 isActive
                   ? cn(
@@ -216,8 +179,8 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
         href={item.href || "#"}
         className={cn(
           "group flex items-center justify-between px-6 py-4 text-base font-medium",
-          getBorderRadiusClass(),
-          getAnimationClass(),
+          borderRadiusClass,
+          animationClass,
           item.disabled && "opacity-50 cursor-not-allowed pointer-events-none",
           isActive
             ? cn(
@@ -296,8 +259,8 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
         className={cn(
           "sidebar fixed inset-y-0 z-50 w-80 bg-gradient-to-b from-sidebar via-sidebar/98 to-sidebar border-r-2 border-sidebar-border transform lg:translate-x-0 custom-scrollbar overflow-y-auto",
           "backdrop-blur-sm",
-          getShadowClass(),
-          getAnimationClass(),
+          shadowClass,
+          animationClass,
           direction === "rtl" ? "right-0" : "left-0",
           open
             ? "translate-x-0"
@@ -313,8 +276,8 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
               <div
                 className={cn(
                   "w-12 h-12 bg-primary flex items-center justify-center shadow-lg",
-                  getBorderRadiusClass(),
-                  getAnimationClass(),
+                  borderRadiusClass,
+                  animationClass,
                   "hover:scale-105 hover:shadow-xl"
                 )}
               >
@@ -336,8 +299,8 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
               size="icon"
               className={cn(
                 "lg:hidden text-sidebar-foreground hover:bg-sidebar-accent",
-                getBorderRadiusClass(),
-                getAnimationClass(),
+                borderRadiusClass,
+                animationClass,
                 "shadow-md hover:shadow-lg hover:scale-105"
               )}
               onClick={() => onOpenChange(false)}
@@ -353,9 +316,9 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
                 className={cn(
                   "flex items-center space-x-4 rtl:space-x-reverse p-4",
                   "bg-gradient-to-br from-primary/5 to-primary/2 border border-primary/10",
-                  getBorderRadiusClass(),
-                  getShadowClass(),
-                  getAnimationClass(),
+                  borderRadiusClass,
+                  shadowClass,
+                  animationClass,
                   "hover:shadow-xl"
                 )}
               >
@@ -363,7 +326,7 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
                   <Avatar
                     className={cn(
                       "h-16 w-16 ring-2 ring-primary/30 shadow-lg",
-                      getAnimationClass(),
+                      animationClass,
                       "hover:scale-105"
                     )}
                   >
@@ -418,9 +381,19 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
           )}
 
           {/* Navigation */}
-          <nav className={cn("flex-1 overflow-y-auto", getSpacingClass())}>
-            {navigation.map((item) => renderNavigationItem(item))}
-          </nav>
+        <nav
+          className={cn(
+            "flex-1 overflow-y-auto",
+            getSpacingClass({
+              compact: "p-2 space-y-1",
+              comfortable: "p-8 space-y-6",
+              spacious: "p-12 space-y-8",
+              default: "p-6 space-y-4",
+            })
+          )}
+        >
+          {navigation.map((item) => renderNavigationItem(item))}
+        </nav>
         </div>
       </div>
     </>

--- a/components/layout/compact-header.tsx
+++ b/components/layout/compact-header.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
-import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
@@ -17,47 +17,28 @@ interface CompactHeaderProps {
 export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
   const { theme, setTheme } = useTheme();
   const { language, setLanguage, t, direction } = useI18n();
-  const { headerStyle, animationLevel, buttonStyle } = useSettings();
+  const {
+    getHeaderStyleClass,
+    getAnimationClass,
+    getButtonStyleClass,
+  } = useLayoutStyles();
 
-  const getHeaderStyleClass = () => {
-    switch (headerStyle) {
-      case "compact":
-        return "h-14 px-3";
-      case "elevated":
-        return "h-16 px-4 shadow-lg";
-      case "transparent":
-        return "h-16 px-4 bg-transparent backdrop-blur-md";
-      default:
-        return "h-16 px-4";
-    }
-  };
-
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-200";
-    if (animationLevel === "moderate") return "transition-all duration-300";
-    return "transition-all duration-500";
-  };
-
-  const getButtonStyleClass = () => {
-    switch (buttonStyle) {
-      case "rounded":
-        return "rounded-full";
-      case "sharp":
-        return "rounded-none";
-      case "modern":
-        return "rounded-2xl";
-      default:
-        return "rounded-xl";
-    }
-  };
+  const buttonClass = getButtonStyleClass({
+    modern: "rounded-2xl",
+    default: "rounded-xl",
+  });
 
   return (
     <header
       className={cn(
         "fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-background via-background/98 to-background border-b border-border/80",
         "shadow-lg shadow-primary/5 backdrop-blur-xl",
-        getHeaderStyleClass(),
+        getHeaderStyleClass({
+          compact: "h-14 px-3",
+          elevated: "h-16 px-4 shadow-lg",
+          transparent: "h-16 px-4 bg-transparent backdrop-blur-md",
+          default: "h-16 px-4",
+        }),
         getAnimationClass()
       )}
     >
@@ -81,7 +62,7 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
             className={cn(
               "lg:hidden h-8 w-8 hover:bg-primary/10",
               "shadow-sm hover:shadow-md hover:scale-105",
-              getButtonStyleClass(),
+              buttonClass,
               getAnimationClass()
             )}
             onClick={() => onchange(false)}
@@ -98,7 +79,7 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
             className={cn(
               "lg:hidden h-9 w-9 hover:bg-primary/10 hover:text-primary",
               "shadow-sm hover:shadow-md hover:scale-105",
-              getButtonStyleClass(),
+              buttonClass,
               getAnimationClass()
             )}
             onClick={onMenuClick}
@@ -123,7 +104,7 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
                 "w-full h-9 border-0 bg-muted/50 shadow-sm",
                 "focus:bg-background focus:ring-2 focus:ring-primary/20 focus:shadow-md",
                 getAnimationClass(),
-                getButtonStyleClass(),
+                buttonClass,
                 direction === "rtl" ? "pr-9 text-right" : "pl-9"
               )}
             />
@@ -139,7 +120,7 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
             className={cn(
               "h-9 w-9 hover:bg-primary/10 hover:text-primary",
               "shadow-sm hover:shadow-md hover:scale-105",
-              getButtonStyleClass(),
+              buttonClass,
               getAnimationClass()
             )}
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
@@ -155,7 +136,7 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
             className={cn(
               "h-9 w-9 hover:bg-primary/10 hover:text-primary",
               "shadow-sm hover:shadow-md hover:scale-105",
-              getButtonStyleClass(),
+              buttonClass,
               getAnimationClass()
             )}
             onClick={() => setLanguage(language === "ar" ? "en" : "ar")}

--- a/components/layout/compact-sidebar.tsx
+++ b/components/layout/compact-sidebar.tsx
@@ -9,8 +9,9 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { useI18n } from "@/providers/i18n-provider";
 import { useAuth } from "@/providers/auth-provider";
-import { useSettings } from "@/providers/settings-provider";
 import { cn } from "@/lib/utils";
+import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import {
   Collapsible,
   CollapsibleContent,
@@ -32,8 +33,21 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
   const pathname = usePathname();
   const { t, direction } = useI18n();
   const { user } = useAuth();
-  const { sidebarStyle, animationLevel, buttonStyle, spacingSize } =
-    useSettings();
+  const { spacingSize } = useSettings();
+  const {
+    getSidebarStyleClass,
+    getAnimationClass,
+    getButtonStyleClass,
+    getSpacingClass,
+  } = useLayoutStyles();
+  const sidebarStyleClass = getSidebarStyleClass({
+    compact: "w-56",
+    floating: "w-64 m-2 rounded-2xl shadow-2xl",
+    minimal: "w-60 border-r-0 shadow-lg",
+    default: "w-64",
+  });
+  const animationClass = getAnimationClass();
+  const buttonStyleClass = getButtonStyleClass({ modern: "rounded-2xl" });
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
 
   // Get navigation items with translations
@@ -47,51 +61,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
     );
   };
 
-  const getSidebarStyleClass = () => {
-    switch (sidebarStyle) {
-      case "compact":
-        return "w-56";
-      case "floating":
-        return "w-64 m-2 rounded-2xl shadow-2xl";
-      case "minimal":
-        return "w-60 border-r-0 shadow-lg";
-      default:
-        return "w-64";
-    }
-  };
-
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-200";
-    if (animationLevel === "moderate") return "transition-all duration-300";
-    return "transition-all duration-500";
-  };
-
-  const getButtonStyleClass = () => {
-    switch (buttonStyle) {
-      case "rounded":
-        return "rounded-full";
-      case "sharp":
-        return "rounded-none";
-      case "modern":
-        return "rounded-2xl";
-      default:
-        return "rounded-lg";
-    }
-  };
-
-  const getSpacingClass = () => {
-    switch (spacingSize) {
-      case "compact":
-        return "space-y-1 p-2";
-      case "comfortable":
-        return "space-y-3 p-4";
-      case "spacious":
-        return "space-y-4 p-6";
-      default:
-        return "space-y-2 p-3";
-    }
-  };
+  
 
   const renderNavigationItem = (item: NavigationItem, level = 0) => {
     const isActive = isNavigationItemActive(item, pathname);
@@ -111,8 +81,8 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
             <div
               className={cn(
                 "group flex items-center justify-between w-full px-3 py-2 text-sm font-medium cursor-pointer",
-                getButtonStyleClass(),
-                getAnimationClass(),
+                buttonStyleClass,
+                animationClass,
                 item.disabled && "opacity-50 cursor-not-allowed",
                 isActive
                   ? "bg-gradient-to-r from-primary to-primary/90 text-primary-foreground shadow-md"
@@ -124,7 +94,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
                 <div
                   className={cn(
                     "flex items-center justify-center rounded-lg",
-                    getAnimationClass(),
+                    animationClass,
                     "w-8 h-8",
                     isActive
                       ? "bg-white/20"
@@ -135,7 +105,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
                     <Icon
                       className={cn(
                         "w-4 h-4 flex-shrink-0 group-hover:scale-110",
-                        getAnimationClass(),
+                        animationClass,
                         isActive ? "text-white" : "text-primary"
                       )}
                     />
@@ -166,7 +136,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
               <ChevronDown
                 className={cn(
                   "w-4 h-4",
-                  getAnimationClass(),
+                  animationClass,
                   isExpanded && "rotate-180",
                   isActive ? "text-white" : "text-primary"
                 )}
@@ -188,8 +158,8 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
         href={item.href || "#"}
         className={cn(
           "group flex items-center justify-between px-3 py-2 text-sm font-medium",
-          getButtonStyleClass(),
-          getAnimationClass(),
+          buttonStyleClass,
+          animationClass,
           item.disabled && "opacity-50 cursor-not-allowed pointer-events-none",
           isActive
             ? "bg-gradient-to-r from-primary to-primary/90 text-primary-foreground shadow-md"
@@ -202,7 +172,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
           <div
             className={cn(
               "flex items-center justify-center rounded-lg",
-              getAnimationClass(),
+              animationClass,
               "w-8 h-8",
               isActive
                 ? "bg-white/20"
@@ -213,7 +183,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
               <Icon
                 className={cn(
                   "w-4 h-4 flex-shrink-0 group-hover:scale-110",
-                  getAnimationClass(),
+                  animationClass,
                   isActive ? "text-white" : "text-primary"
                 )}
               />
@@ -246,7 +216,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
             <ChevronRight
               className={cn(
                 "w-3 h-3 opacity-0 group-hover:opacity-100",
-                getAnimationClass(),
+                animationClass,
                 isActive ? "text-white" : "text-primary"
               )}
             />
@@ -262,8 +232,8 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
         className={cn(
           "fixed inset-y-0 z-40 bg-gradient-to-b from-background via-background/98 to-background border-r border-border/80 transform lg:translate-x-0 overflow-y-auto sidebar-shadow",
           "backdrop-blur-sm",
-          getSidebarStyleClass(),
-          getAnimationClass(),
+          sidebarStyleClass,
+          animationClass,
           direction === "rtl" ? "right-0" : "left-0",
           open
             ? "translate-x-0"
@@ -280,7 +250,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
               <div
                 className={cn(
                   "flex items-center rounded-xl",
-                  getAnimationClass(),
+                  animationClass,
                   "bg-gradient-to-br from-primary/5 to-primary/2 border border-primary/10",
                   "shadow-sm hover:shadow-md",
                   spacingSize === "compact"
@@ -296,7 +266,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
                   <Avatar
                     className={cn(
                       "ring-1 ring-primary/20 shadow-md hover:scale-105",
-                      getAnimationClass(),
+                      animationClass,
                       spacingSize === "compact"
                         ? "h-8 w-8"
                         : spacingSize === "spacious"
@@ -327,7 +297,17 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
           )}
 
           {/* Navigation */}
-          <nav className={cn("flex-1 overflow-y-auto", getSpacingClass())}>
+          <nav
+            className={cn(
+              "flex-1 overflow-y-auto",
+              getSpacingClass({
+                compact: "space-y-1 p-2",
+                comfortable: "space-y-3 p-4",
+                spacious: "space-y-4 p-6",
+                default: "space-y-2 p-3",
+              })
+            )}
+          >
             {navigation.map((item) => renderNavigationItem(item))}
           </nav>
 

--- a/components/layout/elegant-header.tsx
+++ b/components/layout/elegant-header.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
-import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
@@ -17,40 +17,29 @@ interface ElegantHeaderProps {
 export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
   const { theme, setTheme } = useTheme();
   const { language, setLanguage, t, direction } = useI18n();
-  const { headerStyle, animationLevel, buttonStyle } = useSettings();
+  const {
+    getHeaderStyleClass,
+    getAnimationClass,
+    getButtonStyleClass,
+  } = useLayoutStyles();
 
-  const getHeaderStyleClass = () => {
-    switch (headerStyle) {
-      case "compact":
-        return "h-16";
-      case "elevated":
-        return "h-20 shadow-2xl shadow-primary/15";
-      case "transparent":
-        return "h-20 bg-transparent backdrop-blur-3xl";
-      default:
-        return "h-20";
-    }
-  };
+  const headerClass = getHeaderStyleClass({
+    compact: "h-16",
+    elevated: "h-20 shadow-2xl shadow-primary/15",
+    transparent: "h-20 bg-transparent backdrop-blur-3xl",
+    default: "h-20",
+  });
 
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-300";
-    if (animationLevel === "moderate") return "transition-all duration-500";
-    return "transition-all duration-700 ease-out";
-  };
+  const animationClass = getAnimationClass({
+    minimal: "transition-colors duration-300",
+    moderate: "transition-all duration-500",
+    default: "transition-all duration-700 ease-out",
+  });
 
-  const getButtonStyleClass = () => {
-    switch (buttonStyle) {
-      case "rounded":
-        return "rounded-full";
-      case "sharp":
-        return "rounded-none";
-      case "modern":
-        return "rounded-3xl";
-      default:
-        return "rounded-3xl";
-    }
-  };
+  const buttonClass = getButtonStyleClass({
+    modern: "rounded-3xl",
+    default: "rounded-3xl",
+  });
 
   return (
     <header
@@ -59,8 +48,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
         "bg-gradient-to-r from-background/98 via-background/95 to-background/98",
         "backdrop-blur-3xl border-b border-gradient-to-r from-transparent via-border/60 to-transparent",
         "shadow-2xl shadow-primary/10",
-        getHeaderStyleClass(),
-        getAnimationClass(),
+        headerClass,
+        animationClass,
         "before:absolute before:inset-0 before:bg-gradient-to-r before:from-primary/8 before:via-primary/4 before:to-primary/8 before:opacity-60",
         "after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-gradient-to-r after:from-transparent after:via-primary/50 after:to-transparent"
       )}
@@ -91,8 +80,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
             className={cn(
               "lg:hidden h-8 w-8 hover:bg-primary/10",
               "shadow-sm hover:shadow-md hover:scale-105",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={() => onchange(false)}
           >
@@ -114,8 +103,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
               "hover:scale-110 active:scale-95",
               "backdrop-blur-xl",
               "before:absolute before:inset-0 before:bg-gradient-to-br before:from-white/20 before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={onMenuClick}
           >
@@ -133,8 +122,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
                 "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
                 "blur-lg group-hover:blur-sm group-focus-within:blur-sm",
                 "scale-105 group-hover:scale-100 group-focus-within:scale-100",
-                getButtonStyleClass(),
-                getAnimationClass()
+                buttonClass,
+                animationClass
               )}
             />
             <div
@@ -144,8 +133,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
                 "backdrop-blur-xl border border-border/50",
                 "group-focus-within:border-primary/40 group-hover:border-primary/30",
                 "shadow-lg group-focus-within:shadow-xl group-focus-within:shadow-primary/20",
-                getButtonStyleClass(),
-                getAnimationClass()
+                buttonClass,
+                animationClass
               )}
             />
             <Search
@@ -153,7 +142,7 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
                 "absolute top-1/2 -translate-y-1/2 h-5 w-5 z-10",
                 "text-muted-foreground/60 group-focus-within:text-primary group-hover:text-primary/80",
                 "group-focus-within:scale-110",
-                getAnimationClass(),
+                animationClass,
                 direction === "rtl" ? "right-5" : "left-5"
               )}
             />
@@ -164,8 +153,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
                 "text-base font-medium",
                 "focus:ring-0 focus:outline-none",
                 "placeholder:text-muted-foreground/60 placeholder:font-medium",
-                getButtonStyleClass(),
-                getAnimationClass(),
+                buttonClass,
+                animationClass,
                 direction === "rtl" ? "pr-14 text-right" : "pl-14"
               )}
             />
@@ -187,8 +176,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
               "hover:scale-110 active:scale-95",
               "backdrop-blur-xl",
               "before:absolute before:inset-0 before:bg-gradient-to-br before:from-white/10 before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
           >
@@ -209,8 +198,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
               "hover:scale-110 active:scale-95",
               "backdrop-blur-xl",
               "before:absolute before:inset-0 before:bg-gradient-to-br before:from-white/10 before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={() => setLanguage(language === "ar" ? "en" : "ar")}
           >

--- a/components/layout/floating-header.tsx
+++ b/components/layout/floating-header.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
-import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "@/components/ui/logo";
@@ -17,40 +17,27 @@ interface FloatingHeaderProps {
 export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
   const { theme, setTheme } = useTheme();
   const { language, setLanguage, t, direction } = useI18n();
-  const { headerStyle, animationLevel, buttonStyle } = useSettings();
+  const {
+    getHeaderStyleClass,
+    getAnimationClass,
+    getButtonStyleClass,
+  } = useLayoutStyles();
 
-  const getHeaderStyleClass = () => {
-    switch (headerStyle) {
-      case "compact":
-        return "h-14 top-4";
-      case "elevated":
-        return "h-16 top-6 shadow-3xl shadow-primary/20";
-      case "transparent":
-        return "h-16 top-6 bg-transparent backdrop-blur-3xl";
-      default:
-        return "h-16 top-6";
-    }
-  };
+  const headerClass = getHeaderStyleClass({
+    compact: "h-14 top-4",
+    elevated: "h-16 top-6 shadow-3xl shadow-primary/20",
+    transparent: "h-16 top-6 bg-transparent backdrop-blur-3xl",
+    default: "h-16 top-6",
+  });
 
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-200";
-    if (animationLevel === "moderate") return "transition-all duration-300";
-    return "transition-all duration-500 hover:shadow-3xl hover:shadow-primary/15";
-  };
+  const animationClass = getAnimationClass({
+    default: "transition-all duration-500 hover:shadow-3xl hover:shadow-primary/15",
+  });
 
-  const getButtonStyleClass = () => {
-    switch (buttonStyle) {
-      case "rounded":
-        return "rounded-full";
-      case "sharp":
-        return "rounded-none";
-      case "modern":
-        return "rounded-3xl";
-      default:
-        return "rounded-2xl";
-    }
-  };
+  const buttonClass = getButtonStyleClass({
+    modern: "rounded-3xl",
+    default: "rounded-2xl",
+  });
 
   return (
     <header
@@ -58,9 +45,9 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
         "fixed left-4 right-4 sm:left-8 sm:right-8 z-50",
         "bg-gradient-to-r from-background/98 via-background/95 to-background/98 backdrop-blur-2xl",
         "border border-border/60 shadow-2xl shadow-primary/10",
-        getHeaderStyleClass(),
-        getButtonStyleClass(),
-        getAnimationClass()
+        headerClass,
+        buttonClass,
+        animationClass
       )}
     >
       <div className="flex items-center justify-between h-full px-6">
@@ -73,8 +60,8 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
             className={cn(
               "lg:hidden h-10 w-10 hover:bg-primary/10 hover:text-primary",
               "shadow-md hover:shadow-lg hover:scale-105",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={onMenuClick}
           >
@@ -86,7 +73,7 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
             <div
               className={cn(
                 "w-10 h-10 bg-primary flex items-center justify-center shadow-lg",
-                getButtonStyleClass()
+                buttonClass
               )}
             >
               <Logo
@@ -111,7 +98,7 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
             <Search
               className={cn(
                 "absolute top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground group-focus-within:text-primary",
-                getAnimationClass(),
+                animationClass,
                 direction === "rtl" ? "right-3" : "left-3"
               )}
             />
@@ -120,8 +107,8 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
               className={cn(
                 "w-full h-11 border-0 bg-muted/50 backdrop-blur-sm shadow-sm",
                 "focus:bg-background focus:ring-2 focus:ring-primary/20 focus:shadow-md",
-                getButtonStyleClass(),
-                getAnimationClass(),
+                buttonClass,
+                animationClass,
                 direction === "rtl" ? "pr-10 text-right" : "pl-10"
               )}
             />
@@ -137,8 +124,8 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
             className={cn(
               "h-10 w-10 hover:bg-primary/10 hover:text-primary",
               "shadow-md hover:shadow-lg hover:scale-105",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
           >
@@ -153,8 +140,8 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
             className={cn(
               "h-10 w-10 hover:bg-primary/10 hover:text-primary",
               "shadow-md hover:shadow-lg hover:scale-105",
-              getButtonStyleClass(),
-              getAnimationClass()
+              buttonClass,
+              animationClass
             )}
             onClick={() => setLanguage(language === "ar" ? "en" : "ar")}
           >

--- a/components/layout/minimal-header.tsx
+++ b/components/layout/minimal-header.tsx
@@ -17,7 +17,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
-import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { getNavigationItems } from "@/config/navigation";
@@ -26,52 +26,37 @@ import { Logo } from "@/components/ui/logo";
 export function MinimalHeader() {
   const { theme, setTheme } = useTheme();
   const { language, setLanguage, t, direction } = useI18n();
-  const { headerStyle, animationLevel, buttonStyle } = useSettings();
+  const {
+    getHeaderStyleClass,
+    getAnimationClass,
+    getButtonStyleClass,
+  } = useLayoutStyles();
   const pathname = usePathname();
   const [searchOpen, setSearchOpen] = useState(false);
 
   // Get navigation items with translations from centralized config
   const navigation = getNavigationItems(t);
 
-  const getHeaderStyleClass = () => {
-    switch (headerStyle) {
-      case "compact":
-        return "py-3";
-      case "elevated":
-        return "py-4 shadow-lg";
-      case "transparent":
-        return "py-4 bg-transparent backdrop-blur-md";
-      default:
-        return "py-4";
-    }
-  };
+  const headerClass = getHeaderStyleClass({
+    compact: "py-3",
+    elevated: "py-4 shadow-lg",
+    transparent: "py-4 bg-transparent backdrop-blur-md",
+    default: "py-4",
+  });
 
-  const getAnimationClass = () => {
-    if (animationLevel === "none") return "";
-    if (animationLevel === "minimal") return "transition-colors duration-200";
-    if (animationLevel === "moderate") return "transition-all duration-300";
-    return "transition-all duration-500";
-  };
+  const animationClass = getAnimationClass();
 
-  const getButtonStyleClass = () => {
-    switch (buttonStyle) {
-      case "rounded":
-        return "rounded-full";
-      case "sharp":
-        return "rounded-none";
-      case "modern":
-        return "rounded-2xl";
-      default:
-        return "rounded-md";
-    }
-  };
+  const buttonClass = getButtonStyleClass({
+    modern: "rounded-2xl",
+    default: "rounded-md",
+  });
 
   return (
     <header
       className={cn(
         "fixed top-0 left-0 right-0 z-40 glass border-b border-border",
-        getHeaderStyleClass(),
-        getAnimationClass()
+        headerClass,
+        animationClass
       )}
     >
       <div className="flex items-center justify-between px-6">
@@ -81,7 +66,7 @@ export function MinimalHeader() {
             <div
               className={cn(
                 "w-10 h-10 bg-primary flex items-center justify-center shadow-md",
-                getButtonStyleClass()
+                buttonClass
               )}
             >
               <Logo size="sm" className="text-primary-foreground" />
@@ -103,8 +88,8 @@ export function MinimalHeader() {
                     href={item.href!}
                     className={cn(
                       "px-3 py-2 text-sm font-medium relative",
-                      getButtonStyleClass(),
-                      getAnimationClass(),
+                      buttonClass,
+                      animationClass,
                       isActive
                         ? "bg-primary text-primary-foreground"
                         : "text-foreground/70 hover:bg-accent hover:text-accent-foreground"
@@ -127,7 +112,7 @@ export function MinimalHeader() {
               <Button
                 variant="ghost"
                 size="icon"
-                className={cn(getButtonStyleClass(), getAnimationClass())}
+                className={cn(buttonClass, animationClass)}
               >
                 <Menu className="h-5 w-5" />
               </Button>
@@ -178,8 +163,8 @@ export function MinimalHeader() {
               size="icon"
               className={cn(
                 "absolute right-0 top-0",
-                getButtonStyleClass(),
-                getAnimationClass(),
+                buttonClass,
+                animationClass,
                 searchOpen && "opacity-0"
               )}
               onClick={() => setSearchOpen(true)}
@@ -190,8 +175,8 @@ export function MinimalHeader() {
               placeholder={t("common.search")}
               className={cn(
                 "pl-4 pr-10 h-10 bg-muted/50 border-0 focus:bg-background",
-                getButtonStyleClass(),
-                getAnimationClass(),
+                buttonClass,
+                animationClass,
                 searchOpen ? "opacity-100 w-full" : "opacity-0 w-0"
               )}
               onBlur={() => setSearchOpen(false)}
@@ -207,8 +192,8 @@ export function MinimalHeader() {
                 size="icon"
                 className={cn(
                   "hover-lift",
-                  getButtonStyleClass(),
-                  getAnimationClass()
+                  buttonClass,
+                  animationClass
                 )}
               >
                 <Globe className="w-5 h-5" />
@@ -232,8 +217,8 @@ export function MinimalHeader() {
                 size="icon"
                 className={cn(
                   "hover-lift",
-                  getButtonStyleClass(),
-                  getAnimationClass()
+                  buttonClass,
+                  animationClass
                 )}
               >
                 <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/components/layout/navigation-header.tsx
+++ b/components/layout/navigation-header.tsx
@@ -16,6 +16,7 @@ import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useAuth } from "@/providers/auth-provider";
 import { useSettings } from "@/providers/settings-provider";
+import { useLayoutStyles } from "./use-layout-styles";
 import { navigation } from "@/config/navigation";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -50,7 +51,9 @@ export function NavigationHeader({
   const { theme, setTheme } = useTheme();
   const { language, direction, t, setLanguage } = useI18n();
   const { user, logout } = useAuth();
-  const { colorTheme, cardStyle, animationLevel } = useSettings();
+  const { colorTheme, cardStyle } = useSettings();
+  const { getAnimationClass } = useLayoutStyles();
+  const animationClass = getAnimationClass();
 
   const toggleTheme = () => {
     setTheme(theme === "dark" ? "light" : "dark");
@@ -59,7 +62,8 @@ export function NavigationHeader({
   return (
     <header
       className={cn(
-        "fixed top-0 left-0 right-0 z-30 h-16 backdrop-blur-xl border-b transition-all duration-300 header-shadow",
+        "fixed top-0 left-0 right-0 z-30 h-16 backdrop-blur-xl border-b header-shadow",
+        animationClass,
         cardStyle === "glass"
           ? "bg-background/80 border-border/30"
           : cardStyle === "solid"
@@ -70,8 +74,8 @@ export function NavigationHeader({
       {/* Header Content Container */}
       <div
         className={cn(
-          "h-full flex items-center justify-between px-4 lg:px-6 transition-all duration-300",
-          animationLevel !== "none" && "transition-all duration-300",
+          "h-full flex items-center justify-between px-4 lg:px-6",
+          animationClass,
           // Dynamic margins based on sidebar states
           direction === "rtl"
             ? cn(

--- a/components/layout/use-layout-styles.ts
+++ b/components/layout/use-layout-styles.ts
@@ -4,6 +4,7 @@ import type {
   BorderRadius,
   ButtonStyle,
   HeaderStyle,
+  SidebarStyle,
   ShadowIntensity,
   SpacingSize,
 } from "@/providers/settings-provider";
@@ -12,6 +13,7 @@ import type {
 export function useLayoutStyles() {
   const {
     headerStyle,
+    sidebarStyle,
     spacingSize,
     borderRadius,
     animationLevel,
@@ -41,6 +43,10 @@ export function useLayoutStyles() {
   const getHeaderStyleClass = (
     mapping: Record<HeaderStyle | "default", string>
   ) => merge(headerStyle, mapping);
+
+  const getSidebarStyleClass = (
+    mapping: Record<SidebarStyle | "default", string>
+  ) => merge(sidebarStyle, mapping);
 
   const getShadowClass = (
     overrides?: Partial<Record<ShadowIntensity | "default", string>>
@@ -88,6 +94,7 @@ export function useLayoutStyles() {
   return {
     getSpacingClass,
     getHeaderStyleClass,
+    getSidebarStyleClass,
     getShadowClass,
     getAnimationClass,
     getBorderRadiusClass,

--- a/components/layout/use-layout-styles.ts
+++ b/components/layout/use-layout-styles.ts
@@ -1,0 +1,98 @@
+import { useSettings } from "@/providers/settings-provider";
+import type {
+  AnimationLevel,
+  BorderRadius,
+  ButtonStyle,
+  HeaderStyle,
+  ShadowIntensity,
+  SpacingSize,
+} from "@/providers/settings-provider";
+
+// Utility hook that exposes common style helpers based on global settings
+export function useLayoutStyles() {
+  const {
+    headerStyle,
+    spacingSize,
+    borderRadius,
+    animationLevel,
+    shadowIntensity,
+    buttonStyle,
+  } = useSettings();
+
+  const merge = <T extends string>(
+    value: T,
+    base: Record<string, string>,
+    overrides?: Partial<Record<string, string>>
+  ) => {
+    const map = { ...base, ...overrides };
+    return map[value] ?? map.default ?? "";
+  };
+
+  const getSpacingClass = (
+    overrides?: Partial<Record<SpacingSize | "default", string>>
+  ) =>
+    merge(spacingSize, {
+      compact: "px-4 py-2",
+      comfortable: "px-10 py-6",
+      spacious: "px-12 py-8",
+      default: "px-8 py-4",
+    }, overrides);
+
+  const getHeaderStyleClass = (
+    mapping: Record<HeaderStyle | "default", string>
+  ) => merge(headerStyle, mapping);
+
+  const getShadowClass = (
+    overrides?: Partial<Record<ShadowIntensity | "default", string>>
+  ) =>
+    merge(shadowIntensity, {
+      none: "",
+      subtle: "shadow-sm",
+      moderate: "shadow-lg",
+      strong: "shadow-2xl",
+      default: "shadow-lg",
+    }, overrides);
+
+  const getAnimationClass = (
+    overrides?: Partial<Record<AnimationLevel | "default", string>>
+  ) =>
+    merge(animationLevel, {
+      none: "",
+      minimal: "transition-colors duration-200",
+      moderate: "transition-all duration-300",
+      high: "transition-all duration-500",
+      default: "transition-all duration-500",
+    }, overrides);
+
+  const getBorderRadiusClass = (
+    overrides?: Partial<Record<BorderRadius | "default", string>>
+  ) =>
+    merge(borderRadius, {
+      none: "rounded-none",
+      small: "rounded-sm",
+      large: "rounded-lg",
+      full: "rounded-full",
+      default: "rounded-md",
+    }, overrides);
+
+  const getButtonStyleClass = (
+    overrides?: Partial<Record<ButtonStyle | "default", string>>
+  ) =>
+    merge(buttonStyle, {
+      rounded: "rounded-full",
+      sharp: "rounded-none",
+      modern: "rounded-xl",
+      default: "rounded-lg",
+    }, overrides);
+
+  return {
+    getSpacingClass,
+    getHeaderStyleClass,
+    getShadowClass,
+    getAnimationClass,
+    getBorderRadiusClass,
+    getButtonStyleClass,
+  };
+}
+
+export type LayoutStyleHelpers = ReturnType<typeof useLayoutStyles>;


### PR DESCRIPTION
## Summary
- add `useLayoutStyles` hook for shared layout style logic
- refactor header variants to consume centralized helpers

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1. How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6894f514c908832e8c6c0d943e6f72f5