### PR TITLE
feat: centralize layout utilities

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,16 +10,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAuth } from "@/providers/auth-provider";
 import { useI18n } from "@/providers/i18n-provider";
-import { Loader2, Eye, EyeOff, Globe, Sun, Moon, Monitor } from 'lucide-react';
+import { Eye, EyeOff } from "lucide-react";
 import { Logo } from "@/components/ui/logo";
-import { useTheme } from "next-themes";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { LanguageSwitcher } from "@/components/layout/common/language-switcher";
+import { ThemeSwitcher } from "@/components/layout/common/theme-switcher";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
@@ -29,8 +24,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
 
   const { login, isAuthenticated } = useAuth();
-  const { t, language, setLanguage } = useI18n();
-  const { theme, setTheme } = useTheme();
+  const { t } = useI18n();
   const router = useRouter();
 
   useEffect(() => {
@@ -56,11 +50,11 @@ export default function LoginPage() {
         router.replace("/");
       } else {
         console.log("Login failed");
-        setError(t("auth.loginError") || "خطأ في تسجيل الدخول");
+        setError(t("auth.loginError"));
       }
     } catch (error) {
       console.error("Login submission error:", error);
-      setError("خطأ في الاتصال بالخادم. يرجى المحاولة مرة أخرى.");
+      setError(t("auth.connectionError"));
     }
 
     setIsLoading(false);
@@ -72,7 +66,7 @@ export default function LoginPage() {
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/20 via-background to-secondary/20">
         <div className="text-center">
           <LoadingSpinner size="md" showText={false} />
-          <p className="mt-4">جاري التحويل...</p>
+          <p className="mt-4">{t("auth.redirecting")}</p>
         </div>
       </div>
     );
@@ -85,52 +79,8 @@ export default function LoginPage() {
 
       {/* Language and Theme Switchers */}
       <div className="absolute top-4 right-4 flex items-center gap-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              className="glass bg-transparent"
-            >
-              <Globe className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => setLanguage("ar")}>
-              🇸🇦 العربية
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setLanguage("en")}>
-              🇺🇸 English
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="icon"
-              className="glass bg-transparent"
-            >
-              <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-              <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => setTheme("light")}>
-              <Sun className="mr-2 h-4 w-4" />
-              فاتح
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme("dark")}>
-              <Moon className="mr-2 h-4 w-4" />
-              داكن
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme("system")}>
-              <Monitor className="mr-2 h-4 w-4" />
-              النظام
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <LanguageSwitcher buttonClassName="glass bg-transparent" />
+        <ThemeSwitcher buttonClassName="glass bg-transparent" />
       </div>
 
       <Card className="w-full max-w-md glass hover-lift animate-fade-in">
@@ -157,7 +107,7 @@ export default function LoginPage() {
                 onChange={(e) => setUsername(e.target.value)}
                 required
                 className="h-12"
-                placeholder="superadmin"
+                placeholder={t("auth.usernamePlaceholder")}
                 disabled={isLoading}
               />
             </div>

--- a/components/layout/classic-header.tsx
+++ b/components/layout/classic-header.tsx
@@ -1,30 +1,20 @@
 "use client";
 
-import { Menu, Search, Sun, Moon, Globe, Monitor } from "lucide-react";
+import { Menu, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
-import { useAuth } from "@/providers/auth-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
+import { LanguageSwitcher, ThemeSwitcher } from "./common";
 
 interface ClassicHeaderProps {
   onMenuClick: () => void;
 }
 
 export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
-  const { theme, setTheme } = useTheme();
-  const { language, setLanguage, t, direction } = useI18n();
-  const { user } = useAuth();
+  const { t } = useI18n();
   const {
     getSpacingClass,
     getHeaderStyleClass,
@@ -89,85 +79,24 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
             />
           </div>
 
-          {/* Language Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  "hover:bg-primary/10 hover:text-primary",
-                  getBorderRadiusClass(),
-                  animationClass,
-                  "shadow-md hover:shadow-lg hover:scale-105"
-                )}
-              >
-                <Globe className="w-5 h-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align={direction === "rtl" ? "start" : "end"}
-              className={cn(getBorderRadiusClass(), "shadow-xl")}
-            >
-              <DropdownMenuItem
-                onClick={() => setLanguage("ar")}
-                className="rounded-lg"
-              >
-                🇸🇦 {t("language.arabic")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setLanguage("en")}
-                className="rounded-lg"
-              >
-                🇺🇸 {t("language.english")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Theme Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  "hover:bg-primary/10 hover:text-primary",
-                  getBorderRadiusClass(),
-                  animationClass,
-                  "shadow-md hover:shadow-lg hover:scale-105"
-                )}
-              >
-                <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align={direction === "rtl" ? "start" : "end"}
-              className={cn(getBorderRadiusClass(), "shadow-xl")}
-            >
-              <DropdownMenuItem
-                onClick={() => setTheme("light")}
-                className="rounded-lg"
-              >
-                <Sun className="mr-2 h-4 w-4" />
-                {t("theme.light")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setTheme("dark")}
-                className="rounded-lg"
-              >
-                <Moon className="mr-2 h-4 w-4" />
-                {t("theme.dark")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setTheme("system")}
-                className="rounded-lg"
-              >
-                <Monitor className="mr-2 h-4 w-4" />
-                {t("theme.system")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <LanguageSwitcher
+            buttonClassName={cn(
+              "hover:bg-primary/10 hover:text-primary",
+              getBorderRadiusClass(),
+              animationClass,
+              "shadow-md hover:shadow-lg hover:scale-105"
+            )}
+            contentClassName={cn(getBorderRadiusClass(), "shadow-xl")}
+          />
+          <ThemeSwitcher
+            buttonClassName={cn(
+              "hover:bg-primary/10 hover:text-primary",
+              getBorderRadiusClass(),
+              animationClass,
+              "shadow-md hover:shadow-lg hover:scale-105"
+            )}
+            contentClassName={cn(getBorderRadiusClass(), "shadow-xl")}
+          />
 
           {/* User Profile Dropdown */}
           <UserProfileDropdown variant="default" />

--- a/components/layout/classic-header.tsx
+++ b/components/layout/classic-header.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Menu, Search } from "lucide-react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
-import { LanguageSwitcher, ThemeSwitcher } from "./common";
+import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
 
 interface ClassicHeaderProps {
   onMenuClick: () => void;
@@ -65,19 +64,17 @@ export function ClassicHeader({ onMenuClick }: ClassicHeaderProps) {
 
         {/* Right side */}
         <div className="flex items-center space-x-6 rtl:space-x-reverse">
-          {/* Search */}
-          <div className="relative hidden md:block">
-            <Search className="absolute left-3 rtl:left-auto rtl:right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-            <Input
-              placeholder={t("common.search")}
-              className={cn(
-                "pl-10 rtl:pl-4 rtl:pr-10 w-64 bg-muted/50 border-0 focus:bg-background",
-                getBorderRadiusClass(),
-                animationClass,
-                "shadow-sm focus:shadow-md hover:shadow-md"
-              )}
-            />
-          </div>
+          <HeaderSearch
+            containerClassName="hidden md:block"
+            inputClassName={cn(
+              "w-64 bg-muted/50 border-0 focus:bg-background",
+              getBorderRadiusClass(),
+              animationClass,
+              "shadow-sm focus:shadow-md hover:shadow-md",
+              "pl-10 rtl:pl-4 rtl:pr-10"
+            )}
+            iconClassName="left-3 rtl:left-auto rtl:right-3"
+          />
 
           <LanguageSwitcher
             buttonClassName={cn(

--- a/components/layout/common/index.ts
+++ b/components/layout/common/index.ts
@@ -1,2 +1,3 @@
 export * from "./language-switcher"
 export * from "./theme-switcher"
+export * from "./search-input"

--- a/components/layout/common/index.ts
+++ b/components/layout/common/index.ts
@@ -1,0 +1,2 @@
+export * from "./language-switcher"
+export * from "./theme-switcher"

--- a/components/layout/common/language-switcher.tsx
+++ b/components/layout/common/language-switcher.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { Globe } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useI18n } from "@/providers/i18n-provider"
+import { cn } from "@/lib/utils"
+
+interface LanguageSwitcherProps {
+  buttonClassName?: string
+  contentClassName?: string
+}
+
+export function LanguageSwitcher({ buttonClassName, contentClassName }: LanguageSwitcherProps) {
+  const { setLanguage, t, direction } = useI18n()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className={cn(buttonClassName)}>
+          <Globe className="w-5 h-5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align={direction === "rtl" ? "start" : "end"}
+        className={cn(contentClassName)}
+      >
+        <DropdownMenuItem onClick={() => setLanguage("ar")}>
+          🇸🇦 {t("language.arabic") || "العربية"}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setLanguage("en")}>
+          🇺🇸 {t("language.english") || "English"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+

--- a/components/layout/common/search-input.tsx
+++ b/components/layout/common/search-input.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { useI18n } from "@/providers/i18n-provider"
+import { cn } from "@/lib/utils"
+import type { InputHTMLAttributes } from "react"
+
+interface HeaderSearchProps extends InputHTMLAttributes<HTMLInputElement> {
+  placeholderKey?: string
+  containerClassName?: string
+  inputClassName?: string
+  iconClassName?: string
+}
+
+export function HeaderSearch({
+  placeholderKey = "common.search",
+  containerClassName,
+  inputClassName,
+  iconClassName,
+  ...inputProps
+}: HeaderSearchProps) {
+  const { t, direction } = useI18n()
+  const isRTL = direction === "rtl"
+
+  return (
+    <div className={cn("relative", containerClassName)}>
+      <Search
+        className={cn(
+          "absolute top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground",
+          isRTL ? "right-3" : "left-3",
+          iconClassName
+        )}
+      />
+      <Input
+        placeholder={t(placeholderKey)}
+        className={cn(
+          isRTL ? "pr-9 text-right" : "pl-9",
+          inputClassName
+        )}
+        {...inputProps}
+      />
+    </div>
+  )
+}

--- a/components/layout/common/theme-switcher.tsx
+++ b/components/layout/common/theme-switcher.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { Sun, Moon, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { useTheme } from "next-themes"
+import { useI18n } from "@/providers/i18n-provider"
+import { cn } from "@/lib/utils"
+
+interface ThemeSwitcherProps {
+  buttonClassName?: string
+  contentClassName?: string
+}
+
+export function ThemeSwitcher({ buttonClassName, contentClassName }: ThemeSwitcherProps) {
+  const { setTheme } = useTheme()
+  const { t, direction } = useI18n()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className={cn(buttonClassName)}>
+          <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align={direction === "rtl" ? "start" : "end"}
+        className={cn(contentClassName)}
+      >
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="mr-2 h-4 w-4" />
+          {t("theme.light") || "فاتح"}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="mr-2 h-4 w-4" />
+          {t("theme.dark") || "داكن"}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="mr-2 h-4 w-4" />
+          {t("theme.system") || "النظام"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+

--- a/components/layout/compact-header.tsx
+++ b/components/layout/compact-header.tsx
@@ -1,28 +1,27 @@
 "use client";
 
-import { Search, Menu, Sun, Moon, Globe, X } from "lucide-react";
+import { Search, Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
+import { LanguageSwitcher, ThemeSwitcher } from "./common";
 
 interface CompactHeaderProps {
   onMenuClick: () => void;
 }
 
 export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
-  const { theme, setTheme } = useTheme();
-  const { language, setLanguage, t, direction } = useI18n();
+  const { t, direction } = useI18n();
   const {
     getHeaderStyleClass,
     getAnimationClass,
     getButtonStyleClass,
   } = useLayoutStyles();
-
+  const animationClass = getAnimationClass();
   const buttonClass = getButtonStyleClass({
     modern: "rounded-2xl",
     default: "rounded-xl",
@@ -113,36 +112,23 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
 
         {/* Right Section */}
         <div className="flex items-center space-x-2 rtl:space-x-reverse">
-          {/* Theme Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
+          <ThemeSwitcher
+            buttonClassName={cn(
               "h-9 w-9 hover:bg-primary/10 hover:text-primary",
               "shadow-sm hover:shadow-md hover:scale-105",
               buttonClass,
-              getAnimationClass()
+              animationClass
             )}
-            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          >
-            <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-            <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          </Button>
+          />
 
-          {/* Language Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
+          <LanguageSwitcher
+            buttonClassName={cn(
               "h-9 w-9 hover:bg-primary/10 hover:text-primary",
               "shadow-sm hover:shadow-md hover:scale-105",
               buttonClass,
-              getAnimationClass()
+              animationClass
             )}
-            onClick={() => setLanguage(language === "ar" ? "en" : "ar")}
-          >
-            <Globe className="h-4 w-4" />
-          </Button>
+          />
 
           {/* User Profile Dropdown */}
           <UserProfileDropdown variant="compact" showName={false} />

--- a/components/layout/compact-header.tsx
+++ b/components/layout/compact-header.tsx
@@ -1,21 +1,20 @@
 "use client";
 
-import { Search, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
-import { LanguageSwitcher, ThemeSwitcher } from "./common";
+import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
 
 interface CompactHeaderProps {
   onMenuClick: () => void;
 }
 
 export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
-  const { t, direction } = useI18n();
+  const { t } = useI18n();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -87,27 +86,17 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
           </Button>
         </div>
 
-        {/* Center Section - Search */}
         <div className="flex-1 max-w-sm mx-4">
-          <div className="relative group">
-            <Search
-              className={cn(
-                "absolute top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground group-focus-within:text-primary",
-                getAnimationClass(),
-                direction === "rtl" ? "right-3" : "left-3"
-              )}
-            />
-            <Input
-              placeholder={t("nav.search")}
-              className={cn(
-                "w-full h-9 border-0 bg-muted/50 shadow-sm",
-                "focus:bg-background focus:ring-2 focus:ring-primary/20 focus:shadow-md",
-                getAnimationClass(),
-                buttonClass,
-                direction === "rtl" ? "pr-9 text-right" : "pl-9"
-              )}
-            />
-          </div>
+          <HeaderSearch
+            containerClassName={cn("group", getAnimationClass())}
+            inputClassName={cn(
+              "w-full h-9 border-0 bg-muted/50 shadow-sm",
+              "focus:bg-background focus:ring-2 focus:ring-primary/20 focus:shadow-md",
+              getAnimationClass(),
+              buttonClass
+            )}
+            iconClassName={getAnimationClass()}
+          />
         </div>
 
         {/* Right Section */}

--- a/components/layout/compact-sidebar.tsx
+++ b/components/layout/compact-sidebar.tsx
@@ -314,7 +314,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
           {/* Footer - Version only */}
           <div className="p-3 border-t border-border/80">
             <div className="text-xs text-muted-foreground text-center">
-              v2.1.0
+              {t("app.version")}
             </div>
           </div>
         </div>

--- a/components/layout/elegant-header.tsx
+++ b/components/layout/elegant-header.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { Search, Menu, Sun, Moon, Globe, X } from "lucide-react";
+import { Search, Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
+import { LanguageSwitcher, ThemeSwitcher } from "./common";
 
 interface ElegantHeaderProps {
   onMenuClick: () => void;
 }
 
 export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
-  const { theme, setTheme } = useTheme();
-  const { language, setLanguage, t, direction } = useI18n();
+  const { t, direction } = useI18n();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -163,11 +162,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
 
         {/* Right Section - Enhanced buttons */}
         <div className="relative flex items-center space-x-4 rtl:space-x-reverse z-20">
-          {/* Theme Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
+          <ThemeSwitcher
+            buttonClassName={cn(
               "h-12 w-12",
               "bg-gradient-to-br from-muted/60 via-muted/40 to-muted/20",
               "hover:from-primary/15 hover:via-primary/10 hover:to-primary/5",
@@ -179,17 +175,10 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
               buttonClass,
               animationClass
             )}
-            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          >
-            <Sun className="h-5 w-5 rotate-0 scale-100 transition-all duration-700 dark:-rotate-180 dark:scale-0 text-primary" />
-            <Moon className="absolute h-5 w-5 rotate-180 scale-0 transition-all duration-700 dark:rotate-0 dark:scale-100 text-primary" />
-          </Button>
+          />
 
-          {/* Language Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
+          <LanguageSwitcher
+            buttonClassName={cn(
               "h-12 w-12",
               "bg-gradient-to-br from-muted/60 via-muted/40 to-muted/20",
               "hover:from-primary/15 hover:via-primary/10 hover:to-primary/5",
@@ -201,10 +190,7 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
               buttonClass,
               animationClass
             )}
-            onClick={() => setLanguage(language === "ar" ? "en" : "ar")}
-          >
-            <Globe className="h-5 w-5 text-primary" />
-          </Button>
+          />
 
           {/* User Profile Dropdown */}
           <UserProfileDropdown variant="elegant" showName={true} />

--- a/components/layout/elegant-header.tsx
+++ b/components/layout/elegant-header.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Search, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
-import { LanguageSwitcher, ThemeSwitcher } from "./common";
+import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
 
 interface ElegantHeaderProps {
   onMenuClick: () => void;
@@ -136,18 +135,8 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
                 animationClass
               )}
             />
-            <Search
-              className={cn(
-                "absolute top-1/2 -translate-y-1/2 h-5 w-5 z-10",
-                "text-muted-foreground/60 group-focus-within:text-primary group-hover:text-primary/80",
-                "group-focus-within:scale-110",
-                animationClass,
-                direction === "rtl" ? "right-5" : "left-5"
-              )}
-            />
-            <Input
-              placeholder={t("nav.search")}
-              className={cn(
+            <HeaderSearch
+              inputClassName={cn(
                 "relative w-full h-14 border-0 bg-transparent z-10",
                 "text-base font-medium",
                 "focus:ring-0 focus:outline-none",
@@ -155,6 +144,13 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
                 buttonClass,
                 animationClass,
                 direction === "rtl" ? "pr-14 text-right" : "pl-14"
+              )}
+              iconClassName={cn(
+                "top-1/2 -translate-y-1/2 h-5 w-5 z-10",
+                "text-muted-foreground/60 group-focus-within:text-primary group-hover:text-primary/80",
+                "group-focus-within:scale-110",
+                animationClass,
+                direction === "rtl" ? "right-5" : "left-5"
               )}
             />
           </div>

--- a/components/layout/elegant-sidebar.tsx
+++ b/components/layout/elegant-sidebar.tsx
@@ -440,8 +440,8 @@ export function ElegantSidebar({ open, onOpenChange }: ElegantSidebarProps) {
                   </p>
                   <div className="flex items-center mt-1">
                     <div className="w-1.5 h-1.5 bg-green-500 rounded-full mr-2 rtl:mr-0 rtl:ml-2 animate-pulse" />
-                    <span className="text-xs text-green-600 font-medium">
-                      ONLINE
+                    <span className="text-xs text-green-600 font-medium uppercase">
+                      {t("status.online")}
                     </span>
                   </div>
                 </div>
@@ -468,7 +468,7 @@ export function ElegantSidebar({ open, onOpenChange }: ElegantSidebarProps) {
             )}
           >
             <div className="text-xs text-muted-foreground/60 text-center font-medium">
-              v2.1.0
+              {t("app.version")}
             </div>
           </div>
         </div>

--- a/components/layout/floating-header.tsx
+++ b/components/layout/floating-header.tsx
@@ -1,21 +1,20 @@
 "use client";
 
-import { Search, Menu } from "lucide-react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "@/components/ui/logo";
-import { LanguageSwitcher, ThemeSwitcher } from "./common";
+import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
 
 interface FloatingHeaderProps {
   onMenuClick: () => void;
 }
 
 export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
-  const { t, direction } = useI18n();
+  const { t } = useI18n();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -91,27 +90,17 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
           </div>
         </div>
 
-        {/* Center Section - Search */}
         <div className="flex-1 max-w-md mx-4 lg:mx-8">
-          <div className="relative group">
-            <Search
-              className={cn(
-                "absolute top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground group-focus-within:text-primary",
-                animationClass,
-                direction === "rtl" ? "right-3" : "left-3"
-              )}
-            />
-            <Input
-              placeholder={t("nav.search")}
-              className={cn(
-                "w-full h-11 border-0 bg-muted/50 backdrop-blur-sm shadow-sm",
-                "focus:bg-background focus:ring-2 focus:ring-primary/20 focus:shadow-md",
-                buttonClass,
-                animationClass,
-                direction === "rtl" ? "pr-10 text-right" : "pl-10"
-              )}
-            />
-          </div>
+          <HeaderSearch
+            containerClassName={cn("group", animationClass)}
+            inputClassName={cn(
+              "w-full h-11 border-0 bg-muted/50 backdrop-blur-sm shadow-sm",
+              "focus:bg-background focus:ring-2 focus:ring-primary/20 focus:shadow-md",
+              buttonClass,
+              animationClass
+            )}
+            iconClassName={animationClass}
+          />
         </div>
 
         {/* Right Section */}

--- a/components/layout/floating-header.tsx
+++ b/components/layout/floating-header.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { Search, Menu, Sun, Moon, Globe } from "lucide-react";
+import { Search, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "@/components/ui/logo";
+import { LanguageSwitcher, ThemeSwitcher } from "./common";
 
 interface FloatingHeaderProps {
   onMenuClick: () => void;
 }
 
 export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
-  const { theme, setTheme } = useTheme();
-  const { language, setLanguage, t, direction } = useI18n();
+  const { t, direction } = useI18n();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -117,36 +116,23 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
 
         {/* Right Section */}
         <div className="flex items-center space-x-3 rtl:space-x-reverse">
-          {/* Theme Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
+          <ThemeSwitcher
+            buttonClassName={cn(
               "h-10 w-10 hover:bg-primary/10 hover:text-primary",
               "shadow-md hover:shadow-lg hover:scale-105",
               buttonClass,
               animationClass
             )}
-            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          >
-            <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-            <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          </Button>
+          />
 
-          {/* Language Toggle */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
+          <LanguageSwitcher
+            buttonClassName={cn(
               "h-10 w-10 hover:bg-primary/10 hover:text-primary",
               "shadow-md hover:shadow-lg hover:scale-105",
               buttonClass,
               animationClass
             )}
-            onClick={() => setLanguage(language === "ar" ? "en" : "ar")}
-          >
-            <Globe className="h-4 w-4" />
-          </Button>
+          />
 
           {/* User Profile Dropdown */}
           <UserProfileDropdown variant="floating" showName={false} />

--- a/components/layout/floating-navigation.tsx
+++ b/components/layout/floating-navigation.tsx
@@ -337,7 +337,7 @@ export function FloatingNavigation({
                   <div className="flex items-center mt-1">
                     <div className="w-2 h-2 bg-green-500 rounded-full mr-2 rtl:mr-0 rtl:ml-2 animate-pulse" />
                     <span className="text-xs text-green-600 font-medium">
-                      Online
+                      {t("status.online")}
                     </span>
                   </div>
                 </div>
@@ -355,7 +355,7 @@ export function FloatingNavigation({
           {/* Footer - Version only */}
           <div className="p-4 border-t border-border/50">
             <div className="text-xs text-muted-foreground text-center">
-              v2.1.0 • Floating Design
+              {t("app.version")} • {t("app.floatingDesign")}
             </div>
           </div>
         </div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,22 +1,12 @@
 "use client"
 
-import { Menu, Search, Sun, Moon, Globe, Monitor } from "lucide-react"
+import { Menu, Search } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  DropdownMenuSeparator,
-} from "@/components/ui/dropdown-menu"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
-import { useTheme } from "next-themes"
 import { useI18n } from "@/providers/i18n-provider"
-import { useAuth } from "@/providers/auth-provider"
-import Link from "next/link"
 import { cn } from "@/lib/utils"
+import { LanguageSwitcher, ThemeSwitcher } from "./common"
+import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown"
 
 interface HeaderProps {
   onMenuClick: () => void
@@ -24,16 +14,19 @@ interface HeaderProps {
 }
 
 export function Header({ onMenuClick, isModern = false }: HeaderProps) {
-  const { theme, setTheme } = useTheme()
-  const { language, setLanguage, t, direction } = useI18n()
-  const { user, logout } = useAuth()
+  const { t } = useI18n()
 
   return (
-    <header className={cn("sticky top-0 z-40 glass border-b border-border", isModern && "h-20 flex items-center")}>
-      <div className={cn("flex items-center justify-between px-6", isModern ? "py-6" : "py-4")}>
+    <header className={cn("sticky top-0 z-40 glass border-b border-border", isModern && "h-20 flex items-center")}> 
+      <div className={cn("flex items-center justify-between px-6", isModern ? "py-6" : "py-4")}> 
         {/* Left side */}
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
-          <Button variant="ghost" size="icon" className="lg:hidden hover-lift sidebar-trigger" onClick={onMenuClick}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="lg:hidden hover-lift sidebar-trigger"
+            onClick={onMenuClick}
+          >
             <Menu className="w-5 h-5" />
           </Button>
 
@@ -52,77 +45,9 @@ export function Header({ onMenuClick, isModern = false }: HeaderProps) {
 
         {/* Right side */}
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
-          {/* Language Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="hover-lift">
-                <Globe className="w-5 h-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align={direction === "rtl" ? "start" : "end"}>
-              <DropdownMenuItem onClick={() => setLanguage("ar")}>🇸🇦 العربية</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setLanguage("en")}>🇺🇸 English</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Theme Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="hover-lift">
-                <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align={direction === "rtl" ? "start" : "end"}>
-              <DropdownMenuItem onClick={() => setTheme("light")}>
-                <Sun className="mr-2 h-4 w-4" />
-                فاتح
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme("dark")}>
-                <Moon className="mr-2 h-4 w-4" />
-                داكن
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme("system")}>
-                <Monitor className="mr-2 h-4 w-4" />
-                النظام
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-
-
-          {/* User Menu */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="relative h-10 w-10 rounded-full hover-lift">
-                <Avatar className="h-10 w-10">
-                  <AvatarFallback className="bg-primary text-primary-foreground">
-                    {user?.firstName.charAt(0)}
-                    {user?.lastName.charAt(0)}
-                  </AvatarFallback>
-                </Avatar>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align={direction === "rtl" ? "start" : "end"} className="w-56">
-              <div className="flex items-center justify-start gap-2 p-2">
-                <div className="flex flex-col space-y-1 leading-none">
-                  <p className="font-medium">
-                    {user?.firstName} {user?.lastName}
-                  </p>
-                  <p className="w-[200px] truncate text-sm text-muted-foreground">{user?.adminTypeName}</p>
-                </div>
-              </div>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem asChild>
-                <Link href="/dashboard/profile">الملف الشخصي</Link>
-              </DropdownMenuItem>
-              <DropdownMenuItem>الإعدادات</DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={logout} className="text-destructive">
-                {t("nav.logout")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <LanguageSwitcher buttonClassName="hover-lift" />
+          <ThemeSwitcher buttonClassName="hover-lift" />
+          <UserProfileDropdown showName={false} />
         </div>
       </div>
     </header>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { Menu, Search } from "lucide-react"
+import { Menu } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { useI18n } from "@/providers/i18n-provider"
 import { cn } from "@/lib/utils"
-import { LanguageSwitcher, ThemeSwitcher } from "./common"
+import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common"
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown"
 
 interface HeaderProps {
@@ -30,17 +29,15 @@ export function Header({ onMenuClick, isModern = false }: HeaderProps) {
             <Menu className="w-5 h-5" />
           </Button>
 
-          {/* Search */}
-          <div className="relative hidden md:block">
-            <Search className="absolute left-3 rtl:left-auto rtl:right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-            <Input
-              placeholder={t("common.search")}
-              className={cn(
-                "pl-10 rtl:pl-4 rtl:pr-10 bg-muted/50 border-0 focus:bg-background transition-colors",
-                isModern ? "w-96 h-12" : "w-80",
-              )}
-            />
-          </div>
+          <HeaderSearch
+            containerClassName="hidden md:block"
+            inputClassName={cn(
+              "bg-muted/50 border-0 focus:bg-background transition-colors",
+              isModern ? "w-96 h-12" : "w-80",
+              "pl-10 rtl:pl-4 rtl:pr-10"
+            )}
+            iconClassName="left-3 rtl:left-auto rtl:right-3"
+          />
         </div>
 
         {/* Right side */}

--- a/components/layout/minimal-header.tsx
+++ b/components/layout/minimal-header.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Menu, Search, Sun, Moon, Globe, Monitor } from "lucide-react";
+import { Menu, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -15,17 +15,16 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
-import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useLayoutStyles } from "./use-layout-styles";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { getNavigationItems } from "@/config/navigation";
 import { Logo } from "@/components/ui/logo";
+import { LanguageSwitcher, ThemeSwitcher } from "./common";
 
 export function MinimalHeader() {
-  const { theme, setTheme } = useTheme();
-  const { language, setLanguage, t, direction } = useI18n();
+  const { t, direction } = useI18n();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -184,62 +183,12 @@ export function MinimalHeader() {
             />
           </div>
 
-          {/* Language Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  "hover-lift",
-                  buttonClass,
-                  animationClass
-                )}
-              >
-                <Globe className="w-5 h-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align={direction === "rtl" ? "start" : "end"}>
-              <DropdownMenuItem onClick={() => setLanguage("ar")}>
-                🇸🇦 العربية
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setLanguage("en")}>
-                🇺🇸 English
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Theme Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  "hover-lift",
-                  buttonClass,
-                  animationClass
-                )}
-              >
-                <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align={direction === "rtl" ? "start" : "end"}>
-              <DropdownMenuItem onClick={() => setTheme("light")}>
-                <Sun className="mr-2 h-4 w-4" />
-                {t("settings.light")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme("dark")}>
-                <Moon className="mr-2 h-4 w-4" />
-                {t("settings.dark")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme("system")}>
-                <Monitor className="mr-2 h-4 w-4" />
-                {t("settings.system")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <LanguageSwitcher
+            buttonClassName={cn("hover-lift", buttonClass, animationClass)}
+          />
+          <ThemeSwitcher
+            buttonClassName={cn("hover-lift", buttonClass, animationClass)}
+          />
 
           {/* User Profile Dropdown */}
           <UserProfileDropdown variant="minimal" showName={false} />

--- a/components/layout/navigation-header.tsx
+++ b/components/layout/navigation-header.tsx
@@ -6,13 +6,7 @@ import {
   Menu,
   PanelLeftClose,
   PanelLeftOpen,
-  Settings,
-  Globe,
-  Sun,
-  Moon,
-  Monitor,
 } from "lucide-react";
-import { useTheme } from "next-themes";
 import { useI18n } from "@/providers/i18n-provider";
 import { useAuth } from "@/providers/auth-provider";
 import { useSettings } from "@/providers/settings-provider";
@@ -22,14 +16,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { LanguageSwitcher, ThemeSwitcher } from "./common";
 
 interface NavigationHeaderProps {
   onMenuClick: () => void;
@@ -48,16 +35,11 @@ export function NavigationHeader({
   selectedMainItem,
   isMobile,
 }: NavigationHeaderProps) {
-  const { theme, setTheme } = useTheme();
-  const { language, direction, t, setLanguage } = useI18n();
+  const { language, direction, t } = useI18n();
   const { user, logout } = useAuth();
   const { colorTheme, cardStyle } = useSettings();
   const { getAnimationClass } = useLayoutStyles();
   const animationClass = getAnimationClass();
-
-  const toggleTheme = () => {
-    setTheme(theme === "dark" ? "light" : "dark");
-  };
 
   return (
     <header
@@ -188,69 +170,15 @@ export function NavigationHeader({
             <Search className="w-5 h-5" />
           </Button>
 
-          {/* Theme Toggle */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-accent hover:text-accent-foreground"
-                title="Change Theme"
-              >
-                <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => setTheme("light")}>
-                <Sun className="mr-2 h-4 w-4" />
-                فاتح
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme("dark")}>
-                <Moon className="mr-2 h-4 w-4" />
-                داكن
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme("system")}>
-                <Monitor className="mr-2 h-4 w-4" />
-                النظام
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <ThemeSwitcher
+            buttonClassName="hover:bg-accent hover:text-accent-foreground"
+            contentClassName="bg-popover border-border"
+          />
 
-          {/* Language Switcher */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="hover:bg-accent hover:text-accent-foreground"
-                title="Change Language"
-              >
-                <Globe className="w-5 h-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="bg-popover border-border"
-            >
-              <DropdownMenuLabel>
-                {t("layout.language") || "Language"}
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onClick={() => setLanguage("en")}
-                className="hover:bg-accent hover:text-accent-foreground cursor-pointer"
-              >
-                🇺🇸 English
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setLanguage("ar")}
-                className="hover:bg-accent hover:text-accent-foreground cursor-pointer"
-              >
-                🇸🇦 العربية
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <LanguageSwitcher
+            buttonClassName="hover:bg-accent hover:text-accent-foreground"
+            contentClassName="bg-popover border-border"
+          />
 
           {/* User Profile Dropdown */}
           <UserProfileDropdown

--- a/components/layout/navigation-panel-sidebar.tsx
+++ b/components/layout/navigation-panel-sidebar.tsx
@@ -32,7 +32,7 @@ export function NavigationPanelSidebar({
   hasChildren,
 }: NavigationPanelSidebarProps) {
   const pathname = usePathname();
-  const { language, direction, t, setLanguage } = useI18n();
+  const { direction, t } = useI18n();
   const { colorTheme, cardStyle, animationLevel, borderRadius } = useSettings();
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
 

--- a/components/layout/navigation-sidebar.tsx
+++ b/components/layout/navigation-sidebar.tsx
@@ -144,13 +144,9 @@ export function NavigationSidebar({
             <Logo className="w-8 h-8" />
             <div className="flex-1 min-w-0">
               <h1 className="text-white font-semibold text-lg leading-tight break-words">
-                {language === "ar"
-                  ? "منظومة إدارة العقود والسيطرة علي مخزون العالم كله"
-                  : "Contract Management System"}
+                {t("app.tagline")}
               </h1>
-              <p className="text-slate-400 text-sm">
-                {language === "ar" ? "العربية" : "Dashboard"}
-              </p>
+              <p className="text-slate-400 text-sm">{t("nav.dashboard")}</p>
             </div>
           </div>
 
@@ -169,12 +165,8 @@ export function NavigationSidebar({
                 </AvatarFallback>
               </Avatar>
               <div className="flex-1 min-w-0">
-                <p className="text-white font-medium text-sm truncate">
-                  {language === "ar" ? "سيف مصطفى" : "Seif Moustafa"}
-                </p>
-                <p className="text-slate-400 text-xs truncate">
-                  {language === "ar" ? "مدير النظام" : "SuperAdmin"}
-                </p>
+                <p className="text-white font-medium text-sm truncate">{t("common.user")}</p>
+                <p className="text-slate-400 text-xs truncate">{t("nav.profile")}</p>
               </div>
               <div className="w-3 h-3 bg-green-500 rounded-full ring-2 ring-slate-950" />
             </div>
@@ -187,7 +179,7 @@ export function NavigationSidebar({
             >
               <Link href="/dashboard/settings">
                 <Settings className="w-4 h-4" />
-                {language === "ar" ? "الإعدادات" : "Settings"}
+                {t("nav.settings")}
               </Link>
             </Button>
           </div>

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -277,7 +277,7 @@ export function Sidebar({
               isModern && "sidebar-text"
             )}
           >
-            v2.1.0
+            {t("app.version")}
           </div>
         </div>
       </div>

--- a/components/ui/generic-table.tsx
+++ b/components/ui/generic-table.tsx
@@ -56,14 +56,17 @@ export function GenericTable<T extends Record<string, any>>({
   selectable = false,
   selectedItems = [],
   onSelectionChange,
-  searchPlaceholder = "البحث...",
-  emptyMessage = "لا توجد بيانات",
+  searchPlaceholder,
+  emptyMessage,
 }: GenericTableProps<T>) {
   const { t, direction } = useI18n()
   const settings = useSettings()
   const [sortColumn, setSortColumn] = useState<keyof T | null>(null)
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc")
   const [searchTerm, setSearchTerm] = useState("")
+
+  const placeholder = searchPlaceholder ?? t("common.search")
+  const empty = emptyMessage ?? t("common.noData")
 
   const handleSort = (column: keyof T) => {
     if (sortColumn === column) {
@@ -210,7 +213,7 @@ export function GenericTable<T extends Record<string, any>>({
       <div className="relative">
         <Search className="absolute left-3 rtl:left-auto rtl:right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
         <Input
-          placeholder={searchPlaceholder}
+          placeholder={placeholder}
           className="pl-10 rtl:pl-4 rtl:pr-10"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
@@ -220,7 +223,7 @@ export function GenericTable<T extends Record<string, any>>({
       {/* Mobile Cards View */}
       <div className="block md:hidden space-y-4">
         {sortedData.length === 0 ? (
-          <div className="text-center py-12 text-muted-foreground">{emptyMessage}</div>
+          <div className="text-center py-12 text-muted-foreground">{empty}</div>
         ) : (
           sortedData.map((row, index) => {
             const isSelected = selectable && selectedItems.includes(row.id)
@@ -239,7 +242,7 @@ export function GenericTable<T extends Record<string, any>>({
                         }
                       }}
                     />
-                    <span className="text-sm text-muted-foreground">تحديد</span>
+                    <span className="text-sm text-muted-foreground">{t("table.select")}</span>
                   </div>
                 )}
                 {columns.map((column) => (
@@ -337,8 +340,14 @@ export function GenericTable<T extends Record<string, any>>({
                   </TableHead>
                 ))}
                 {actions && actions.length > 0 && (
-                  <TableHead className={cn("w-16", getCellPadding(), direction === "rtl" ? "text-right" : "text-left")}>
-                    الإجراءات
+                  <TableHead
+                    className={cn(
+                      "w-16",
+                      getCellPadding(),
+                      direction === "rtl" ? "text-right" : "text-left"
+                    )}
+                  >
+                    {t("table.actions")}
                   </TableHead>
                 )}
               </TableRow>
@@ -350,7 +359,7 @@ export function GenericTable<T extends Record<string, any>>({
                     colSpan={columns.length + (actions ? 1 : 0) + (selectable ? 1 : 0)}
                     className="h-32 text-center text-muted-foreground"
                   >
-                    {emptyMessage}
+                    {empty}
                   </TableCell>
                 </TableRow>
               ) : (
@@ -430,7 +439,7 @@ export function GenericTable<T extends Record<string, any>>({
             settings.fontSize === "small" ? "text-xs" :
             settings.fontSize === "large" ? "text-base" : "text-sm"
           )}>
-            صفحة {pagination.currentPage} من {pagination.totalPages}
+            {t("table.page")} {pagination.currentPage} {t("table.of")} {pagination.totalPages}
           </p>
           <div className="flex items-center space-x-2 rtl:space-x-reverse">
             <Button
@@ -441,7 +450,7 @@ export function GenericTable<T extends Record<string, any>>({
               className="hover-lift"
             >
               <ChevronRight className="h-4 w-4 rtl:rotate-180" />
-              السابق
+              {t("table.previous")}
             </Button>
             <Button
               variant="outline"
@@ -450,7 +459,7 @@ export function GenericTable<T extends Record<string, any>>({
               disabled={pagination.currentPage === pagination.totalPages}
               className="hover-lift"
             >
-              التالي
+              {t("table.next")}
               <ChevronLeft className="h-4 w-4 rtl:rotate-180" />
             </Button>
           </div>

--- a/components/ui/user-profile-dropdown.tsx
+++ b/components/ui/user-profile-dropdown.tsx
@@ -135,7 +135,7 @@ export function UserProfileDropdown({
                     variant === "navigation" ? "text-xs" : "text-xs"
                   )}
                 >
-                  {user.adminTypeName || user.role || "مستخدم"}
+                  {user.adminTypeName || user.role || t("common.user")}
                 </p>
               </div>
               <ChevronDown
@@ -164,7 +164,7 @@ export function UserProfileDropdown({
           <div className="text-right rtl:text-left min-w-0">
             <p className="font-medium text-sm truncate">{getDisplayName()}</p>
             <p className="text-xs text-muted-foreground truncate">
-              {user.adminTypeName || user.role || "مستخدم"}
+              {user.adminTypeName || user.role || t("common.user")}
             </p>
           </div>
         </div>
@@ -176,7 +176,7 @@ export function UserProfileDropdown({
           className="flex items-center gap-3 p-3 cursor-pointer hover:bg-accent/50 rounded-md"
         >
           <User className="h-4 w-4" />
-          <span>الملف الشخصي</span>
+          <span>{t("nav.profile")}</span>
         </DropdownMenuItem>
 
         <DropdownMenuItem
@@ -184,7 +184,7 @@ export function UserProfileDropdown({
           className="flex items-center gap-3 p-3 cursor-pointer hover:bg-accent/50 rounded-md"
         >
           <Settings className="h-4 w-4" />
-          <span>الإعدادات</span>
+          <span>{t("nav.settings")}</span>
         </DropdownMenuItem>
 
         <DropdownMenuSeparator />
@@ -194,7 +194,7 @@ export function UserProfileDropdown({
           className="flex items-center gap-3 p-3 cursor-pointer hover:bg-destructive/10 text-destructive rounded-md"
         >
           <LogOut className="h-4 w-4" />
-          <span>تسجيل الخروج</span>
+          <span>{t("nav.logout")}</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/config/navigation.ts
+++ b/config/navigation.ts
@@ -51,12 +51,12 @@ export const navigation: NavigationItem[] = [
     icon: Users,
     children: [
       {
-        name: "قائمة المستخدمين",
+        name: "nav.user_list",
         href: "/users",
         icon: Users,
       },
       {
-        name: "أنواع المستخدمين",
+        name: "nav.user_types",
         href: "/user-types",
         icon: Shield,
       },
@@ -68,7 +68,7 @@ export const navigation: NavigationItem[] = [
     icon: BarChart3,
   },
   {
-    name: "الملف الشخصي", // Direct Arabic text
+    name: "nav.profile",
     href: "/profile",
     icon: User,
   },

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -29,6 +29,8 @@ export const ar = {
   "app.minimal": "البسيطة",
   "app.compact": "المدمجة",
   "app.floating": "العائمة",
+  "app.floatingDesign": "تصميم عائم",
+  "app.version": "v2.1.0",
 
   // Logo & Icons
   "logo.type": "sparkles", // Options: "sparkles", "shield", "image", "custom"
@@ -194,6 +196,9 @@ export const ar = {
   "stats.fromLastMonth": "من الشهر الماضي",
   "stats.increase": "زيادة",
   "stats.decrease": "انخفاض",
+
+  // Status
+  "status.online": "متصل",
 
   "nav.main_dashboard": "لوحة التحكم الرئيسية",
   "nav.reports": "التقارير",

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -7,6 +7,9 @@ export const ar = {
   "auth.loginError": "خطأ في اسم المستخدم أو كلمة المرور",
   "auth.welcome": "منظومة إدارة العقود",
   "auth.pleaseLogin": "يرجى تسجيل الدخول للمتابعة",
+  "auth.usernamePlaceholder": "المشرف العام",
+  "auth.connectionError": "خطأ في الاتصال بالخادم. يرجى المحاولة مرة أخرى.",
+  "auth.redirecting": "جاري التحويل...",
 
   // Navigation
   "nav.dashboard": "لوحة التحكم",

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -15,10 +15,14 @@ export const ar = {
   "nav.profile": "الملف الشخصي",
   "nav.settings": "الإعدادات",
   "nav.logout": "تسجيل الخروج",
+  "nav.user_list": "قائمة المستخدمين",
+  "nav.user_types": "أنواع المستخدمين",
+  "nav.menu": "القائمة",
 
   // Layout & App
   "app.title": "نموذج إدارة",
   "app.subtitle": "الإدارية",
+  "app.tagline": "منظومة إدارة العقود والسيطرة علي مخزون العالم كله",
   "app.modern": "العصرية",
   "app.classic": "الكلاسيكية",
   "app.elegant": "الأنيقة",
@@ -93,6 +97,7 @@ export const ar = {
   "layout.minimalDesc": "تصميم بسيط مع شريط علوي فقط وقوائم منسدلة",
   "layout.compactDesc": "تصميم مدمج مع عناصر صغيرة لتوفير مساحة أكبر للمحتوى",
   "layout.floatingDesc": "تصميم عائم مع بطاقات منفصلة وتأثيرات ثلاثية الأبعاد",
+  "layout.items": "عناصر",
 
   // Color Themes
   "color.purple": "أرجواني",
@@ -156,6 +161,10 @@ export const ar = {
   "theme.dark": "داكن",
   "theme.system": "النظام",
 
+  // Language
+  "language.arabic": "العربية",
+  "language.english": "الإنجليزية",
+
   // Common
   "common.search": "البحث...",
   "common.filter": "تصفية",
@@ -171,6 +180,15 @@ export const ar = {
   "common.error": "حدث خطأ",
   "common.success": "تم بنجاح",
   "common.retry": "إعادة المحاولة",
+  "common.user": "مستخدم",
+
+  // Table
+  "table.select": "تحديد",
+  "table.actions": "الإجراءات",
+  "table.page": "صفحة",
+  "table.of": "من",
+  "table.previous": "السابق",
+  "table.next": "التالي",
 
   // Stats
   "stats.fromLastMonth": "من الشهر الماضي",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -29,6 +29,8 @@ export const en = {
   "app.minimal": "Minimal",
   "app.compact": "Compact",
   "app.floating": "Floating",
+  "app.floatingDesign": "Floating Design",
+  "app.version": "v2.1.0",
 
   // Logo & Icons
   "logo.type": "sparkles", // Options: "sparkles", "shield", "image", "custom"
@@ -197,6 +199,9 @@ export const en = {
   "stats.fromLastMonth": "from last month",
   "stats.increase": "increase",
   "stats.decrease": "decrease",
+
+  // Status
+  "status.online": "Online",
 
   "nav.main_dashboard": "Main Dashboard",
   "nav.reports": "Reports",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -7,6 +7,9 @@ export const en = {
   "auth.loginError": "Invalid username or password",
   "auth.welcome": "Welcome to Admin Dashboard",
   "auth.pleaseLogin": "Please sign in to continue",
+  "auth.usernamePlaceholder": "superadmin",
+  "auth.connectionError": "Server connection error. Please try again.",
+  "auth.redirecting": "Redirecting...",
 
   // Navigation
   "nav.dashboard": "Dashboard",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -15,10 +15,14 @@ export const en = {
   "nav.profile": "Profile",
   "nav.settings": "Settings",
   "nav.logout": "Logout",
+  "nav.user_list": "User List",
+  "nav.user_types": "User Types",
+  "nav.menu": "Menu",
 
   // Layout & App
   "app.title": "Admin Dashboard",
   "app.subtitle": "Administrative",
+  "app.tagline": "Contract Management System",
   "app.modern": "Modern",
   "app.classic": "Classic",
   "app.elegant": "Elegant",
@@ -96,6 +100,7 @@ export const en = {
   "layout.compactDesc":
     "Compact design with small elements to maximize content space",
   "layout.floatingDesc": "Floating design with separate cards and 3D effects",
+  "layout.items": "items",
 
   // Color Themes
   "color.purple": "Purple",
@@ -159,6 +164,10 @@ export const en = {
   "theme.dark": "Dark",
   "theme.system": "System",
 
+  // Language
+  "language.arabic": "Arabic",
+  "language.english": "English",
+
   // Common
   "common.search": "Search...",
   "common.filter": "Filter",
@@ -174,6 +183,15 @@ export const en = {
   "common.error": "An error occurred",
   "common.success": "Success",
   "common.retry": "Try Again",
+  "common.user": "User",
+
+  // Table
+  "table.select": "Select",
+  "table.actions": "Actions",
+  "table.page": "Page",
+  "table.of": "of",
+  "table.previous": "Previous",
+  "table.next": "Next",
 
   // Stats
   "stats.fromLastMonth": "from last month",


### PR DESCRIPTION
## Summary
- expand theme and language switchers to all remaining layout headers
- drop redundant layout-specific toggles in favor of shared components
- simplify navigation panel sidebar by removing unused language state

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6895ead0e59c832ea3f1deba1fec1f37