### PR TITLE
Simplify logo configuration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -898,3 +898,19 @@
 [data-layout="navigation"] .navigation-header {
   box-shadow: var(--shadow-sm);
 }
+
+/* Behavior toggles */
+html[data-reduced-motion="true"] *,
+html[data-reduced-motion="true"] *::before,
+html[data-reduced-motion="true"] *::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+html[data-high-contrast="true"] {
+  filter: contrast(1.25) saturate(1.2);
+}
+
+html[data-compact-mode="true"] {
+  --spacing-unit: 0.5rem;
+}

--- a/components/layout/classic-sidebar.tsx
+++ b/components/layout/classic-sidebar.tsx
@@ -27,9 +27,14 @@ import { Logo } from "@/components/ui/logo";
 interface ClassicSidebarProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  collapsible?: boolean;
 }
 
-export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
+export function ClassicSidebar({
+  open,
+  onOpenChange,
+  collapsible = true,
+}: ClassicSidebarProps) {
   const pathname = usePathname();
   const { t, direction } = useI18n();
   const { user } = useAuth();
@@ -207,7 +212,7 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
             : "text-sidebar-foreground/70 hover:bg-gradient-to-r hover:from-primary/10 hover:to-primary/5 hover:text-primary hover:shadow-md"
         )}
         style={{ paddingLeft: `${24 + indent}px` }}
-        onClick={() => !item.disabled && onOpenChange(false)}
+        onClick={() => !item.disabled && collapsible && onOpenChange(false)}
       >
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
           <div
@@ -294,6 +299,7 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
               </div>
             </div>
 
+          {collapsible && (
             <Button
               variant="ghost"
               size="icon"
@@ -307,6 +313,7 @@ export function ClassicSidebar({ open, onOpenChange }: ClassicSidebarProps) {
             >
               <X className="w-5 h-5" />
             </Button>
+          )}
           </div>
 
           {/* User Info */}

--- a/components/layout/compact-header.tsx
+++ b/components/layout/compact-header.tsx
@@ -8,6 +8,7 @@ import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
 import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
+import { useSettings } from "@/providers/settings-provider";
 
 interface CompactHeaderProps {
   onMenuClick: () => void;
@@ -15,6 +16,7 @@ interface CompactHeaderProps {
 
 export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
   const { t } = useI18n();
+  const settings = useSettings();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -54,36 +56,40 @@ export function CompactHeader({ onMenuClick }: CompactHeaderProps) {
             </div>
           </div>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "lg:hidden h-8 w-8 hover:bg-primary/10",
-              "shadow-sm hover:shadow-md hover:scale-105",
-              buttonClass,
-              getAnimationClass()
-            )}
-            onClick={() => onchange(false)}
-          >
-            <X className="w-4 h-4" />
-          </Button>
+          {settings.collapsibleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "lg:hidden h-8 w-8 hover:bg-primary/10",
+                "shadow-sm hover:shadow-md hover:scale-105",
+                buttonClass,
+                getAnimationClass()
+              )}
+              onClick={() => onchange(false)}
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          )}
         </div>
         {/* Left Section */}
         <div className="flex items-center space-x-3 rtl:space-x-reverse">
           {/* Mobile Menu Button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "lg:hidden h-9 w-9 hover:bg-primary/10 hover:text-primary",
-              "shadow-sm hover:shadow-md hover:scale-105",
-              buttonClass,
-              getAnimationClass()
-            )}
-            onClick={onMenuClick}
-          >
-            <Menu className="h-4 w-4" />
-          </Button>
+          {settings.collapsibleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "lg:hidden h-9 w-9 hover:bg-primary/10 hover:text-primary",
+                "shadow-sm hover:shadow-md hover:scale-105",
+                buttonClass,
+                getAnimationClass()
+              )}
+              onClick={onMenuClick}
+            >
+              <Menu className="h-4 w-4" />
+            </Button>
+          )}
         </div>
 
         <div className="flex-1 max-w-sm mx-4">

--- a/components/layout/compact-layout.tsx
+++ b/components/layout/compact-layout.tsx
@@ -73,7 +73,11 @@ export function CompactLayout({
       <CompactHeader onMenuClick={() => onSidebarOpenChange(true)} />
 
       {/* Sidebar */}
-      <CompactSidebar open={sidebarOpen} onOpenChange={onSidebarOpenChange} />
+      <CompactSidebar
+        open={sidebarOpen}
+        onOpenChange={onSidebarOpenChange}
+        collapsible={settings.collapsibleSidebar}
+      />
 
       {/* Main Content - Proper responsive margins */}
       <main
@@ -109,7 +113,7 @@ export function CompactLayout({
         {settings.showFooter && <Footer />}
 
         {/* Mobile overlay */}
-        {sidebarOpen && (
+        {sidebarOpen && settings.collapsibleSidebar && (
           <div
             className={cn(
               "fixed inset-0 bg-black/50 z-30 lg:hidden",

--- a/components/layout/compact-layout.tsx
+++ b/components/layout/compact-layout.tsx
@@ -6,6 +6,7 @@ import { CompactHeader } from "@/components/layout/compact-header";
 import { useI18n } from "@/providers/i18n-provider";
 import { useSettings } from "@/providers/settings-provider";
 import { cn } from "@/lib/utils";
+import { Footer } from "@/components/layout/footer";
 
 interface CompactLayoutProps {
   children: React.ReactNode;
@@ -105,16 +106,18 @@ export function CompactLayout({
         </div>
       </main>
 
-      {/* Mobile overlay */}
-      {sidebarOpen && (
-        <div
-          className={cn(
-            "fixed inset-0 bg-black/50 z-30 lg:hidden",
-            getAnimationClass()
-          )}
-          onClick={() => onSidebarOpenChange(false)}
-        />
-      )}
-    </div>
-  );
-}
+        {settings.showFooter && <Footer />}
+
+        {/* Mobile overlay */}
+        {sidebarOpen && (
+          <div
+            className={cn(
+              "fixed inset-0 bg-black/50 z-30 lg:hidden",
+              getAnimationClass()
+            )}
+            onClick={() => onSidebarOpenChange(false)}
+          />
+        )}
+      </div>
+    );
+  }

--- a/components/layout/compact-sidebar.tsx
+++ b/components/layout/compact-sidebar.tsx
@@ -27,9 +27,14 @@ import { Logo } from "@/components/ui/logo";
 interface CompactSidebarProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  collapsible?: boolean;
 }
 
-export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
+export function CompactSidebar({
+  open,
+  onOpenChange,
+  collapsible = true,
+}: CompactSidebarProps) {
   const pathname = usePathname();
   const { t, direction } = useI18n();
   const { user } = useAuth();
@@ -166,7 +171,7 @@ export function CompactSidebar({ open, onOpenChange }: CompactSidebarProps) {
             : "text-foreground/80 hover:bg-gradient-to-r hover:from-primary/10 hover:to-primary/5 hover:text-primary hover:shadow-sm"
         )}
         style={{ paddingLeft: `${12 + indent}px` }}
-        onClick={() => !item.disabled && onOpenChange(false)}
+        onClick={() => !item.disabled && collapsible && onOpenChange(false)}
       >
         <div className="flex items-center space-x-3 rtl:space-x-reverse">
           <div

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -24,13 +24,23 @@ interface DashboardLayoutProps {
 }
 
 export function DashboardLayout({ children }: DashboardLayoutProps) {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const settings = useSettings();
+  const [sidebarOpen, setSidebarOpen] = useState(
+    settings.collapsibleSidebar ? false : true
+  );
   const [sidebarHovered, setSidebarHovered] = useState(false);
     const { direction } = useI18n();
-    const { layoutTemplate, showFooter } = useSettings();
+    const { layoutTemplate, showFooter, collapsibleSidebar } = settings;
 
-  // Close sidebar when clicking outside on mobile
   useEffect(() => {
+    if (!collapsibleSidebar) {
+      setSidebarOpen(true);
+    }
+  }, [collapsibleSidebar]);
+
+  // Close sidebar when clicking outside on mobile if collapsible
+  useEffect(() => {
+    if (!collapsibleSidebar) return;
     const handleClickOutside = (event: MouseEvent) => {
       const sidebar = document.querySelector(".sidebar");
       const sidebarTrigger = document.querySelector(".sidebar-trigger");
@@ -50,7 +60,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, []);
+  }, [collapsibleSidebar]);
 
   // Navigation Layout - NEW
   if (layoutTemplate === "navigation") {
@@ -110,11 +120,12 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         )}
       >
         {/* Modern sidebar with hover expansion */}
-          <ModernSidebar
-            open={sidebarOpen}
-            onOpenChange={setSidebarOpen}
-            onHoverChange={setSidebarHovered}
-          />
+        <ModernSidebar
+          open={sidebarOpen}
+          onOpenChange={setSidebarOpen}
+          onHoverChange={setSidebarHovered}
+          collapsible={collapsibleSidebar}
+        />
 
         <div
           className={cn(
@@ -138,7 +149,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           </div>
 
         {/* Mobile overlay */}
-        {sidebarOpen && (
+        {sidebarOpen && collapsibleSidebar && (
           <div
             className="fixed inset-0 bg-black/50 z-40 lg:hidden backdrop-blur-sm"
             onClick={() => setSidebarOpen(false)}
@@ -178,7 +189,11 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         )}
       >
         {/* Classic sidebar - wider with larger icons and text */}
-        <ClassicSidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
+        <ClassicSidebar
+          open={sidebarOpen}
+          onOpenChange={setSidebarOpen}
+          collapsible={collapsibleSidebar}
+        />
 
         <div
           className={cn(
@@ -196,7 +211,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         </div>
 
         {/* Mobile overlay */}
-        {sidebarOpen && (
+        {sidebarOpen && collapsibleSidebar && (
           <div
             className="fixed inset-0 bg-black/50 z-40 lg:hidden backdrop-blur-sm"
             onClick={() => setSidebarOpen(false)}
@@ -231,7 +246,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         </div>
 
       {/* Mobile overlay */}
-      {sidebarOpen && (
+      {sidebarOpen && collapsibleSidebar && (
         <div
           className="fixed inset-0 bg-black/50 z-40 lg:hidden backdrop-blur-sm"
           onClick={() => setSidebarOpen(false)}

--- a/components/layout/dashboard-layout.tsx
+++ b/components/layout/dashboard-layout.tsx
@@ -8,6 +8,7 @@ import { MinimalHeader } from "@/components/layout/minimal-header";
 import { ClassicHeader } from "@/components/layout/classic-header";
 import { ClassicSidebar } from "@/components/layout/classic-sidebar";
 import { ModernSidebar } from "@/components/layout/modern-sidebar";
+import { Footer } from "@/components/layout/footer";
 import { useI18n } from "@/providers/i18n-provider";
 import { useSettings } from "@/providers/settings-provider";
 import { cn } from "@/lib/utils";
@@ -25,8 +26,8 @@ interface DashboardLayoutProps {
 export function DashboardLayout({ children }: DashboardLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarHovered, setSidebarHovered] = useState(false);
-  const { direction } = useI18n();
-  const { layoutTemplate } = useSettings();
+    const { direction } = useI18n();
+    const { layoutTemplate, showFooter } = useSettings();
 
   // Close sidebar when clicking outside on mobile
   useEffect(() => {
@@ -109,11 +110,11 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         )}
       >
         {/* Modern sidebar with hover expansion */}
-        <ModernSidebar
-          open={sidebarOpen}
-          onOpenChange={setSidebarOpen}
-          onHoverChange={setSidebarHovered}
-        />
+          <ModernSidebar
+            open={sidebarOpen}
+            onOpenChange={setSidebarOpen}
+            onHoverChange={setSidebarHovered}
+          />
 
         <div
           className={cn(
@@ -128,12 +129,13 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           )}
         >
           {/* Modern header */}
-          <Header onMenuClick={() => setSidebarOpen(true)} isModern={true} />
+            <Header onMenuClick={() => setSidebarOpen(true)} isModern={true} />
 
-          <main className="p-6 pt-24">
-            <div className="animate-fade-in">{children}</div>
-          </main>
-        </div>
+            <main className="p-6 pt-24">
+              <div className="animate-fade-in">{children}</div>
+            </main>
+            {showFooter && <Footer />}
+          </div>
 
         {/* Mobile overlay */}
         {sidebarOpen && (
@@ -156,12 +158,13 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         )}
       >
         {/* Minimal layout has no sidebar, just a header with dropdown navigation */}
-        <MinimalHeader />
+          <MinimalHeader />
 
-        <main className="p-6 pt-20">
-          <div className="animate-fade-in max-w-7xl mx-auto">{children}</div>
-        </main>
-      </div>
+          <main className="p-6 pt-20">
+            <div className="animate-fade-in max-w-7xl mx-auto">{children}</div>
+          </main>
+          {showFooter && <Footer />}
+        </div>
     );
   }
 
@@ -189,6 +192,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
           <main className="p-8">
             <div className="animate-fade-in">{children}</div>
           </main>
+          {showFooter && <Footer />}
         </div>
 
         {/* Mobile overlay */}
@@ -210,20 +214,21 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
         direction === "rtl" ? "rtl" : "ltr"
       )}
     >
-      <Sidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
+        <Sidebar open={sidebarOpen} onOpenChange={setSidebarOpen} />
 
-      <div
-        className={cn(
-          "transition-all duration-300 ease-in-out",
-          direction === "rtl" ? "lg:mr-80" : "lg:ml-80"
-        )}
-      >
-        <Header onMenuClick={() => setSidebarOpen(true)} />
+        <div
+          className={cn(
+            "transition-all duration-300 ease-in-out",
+            direction === "rtl" ? "lg:mr-80" : "lg:ml-80"
+          )}
+        >
+          <Header onMenuClick={() => setSidebarOpen(true)} />
 
-        <main className="p-6">
-          <div className="animate-fade-in">{children}</div>
-        </main>
-      </div>
+          <main className="p-6">
+            <div className="animate-fade-in">{children}</div>
+          </main>
+          {showFooter && <Footer />}
+        </div>
 
       {/* Mobile overlay */}
       {sidebarOpen && (

--- a/components/layout/elegant-header.tsx
+++ b/components/layout/elegant-header.tsx
@@ -8,6 +8,7 @@ import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "../ui/logo";
 import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
+import { useSettings } from "@/providers/settings-provider";
 
 interface ElegantHeaderProps {
   onMenuClick: () => void;
@@ -15,6 +16,7 @@ interface ElegantHeaderProps {
 
 export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
   const { t, direction } = useI18n();
+  const settings = useSettings();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -72,42 +74,46 @@ export function ElegantHeader({ onMenuClick }: ElegantHeaderProps) {
             </div>
           </div>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "lg:hidden h-8 w-8 hover:bg-primary/10",
-              "shadow-sm hover:shadow-md hover:scale-105",
-              buttonClass,
-              animationClass
-            )}
-            onClick={() => onchange(false)}
-          >
-            <X className="w-4 h-4" />
-          </Button>
+          {settings.collapsibleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "lg:hidden h-8 w-8 hover:bg-primary/10",
+                "shadow-sm hover:shadow-md hover:scale-105",
+                buttonClass,
+                animationClass
+              )}
+              onClick={() => onchange(false)}
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          )}
         </div>
         {/* Left Section */}
         <div className="relative flex items-center space-x-4 rtl:space-x-reverse z-20">
           {/* Mobile Menu Button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "lg:hidden h-12 w-12",
-              "bg-gradient-to-br from-primary/15 via-primary/10 to-primary/5",
-              "hover:from-primary/25 hover:via-primary/15 hover:to-primary/10",
-              "border border-primary/20 hover:border-primary/40",
-              "shadow-xl shadow-primary/20 hover:shadow-2xl hover:shadow-primary/30",
-              "hover:scale-110 active:scale-95",
-              "backdrop-blur-xl",
-              "before:absolute before:inset-0 before:bg-gradient-to-br before:from-white/20 before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300",
-              buttonClass,
-              animationClass
-            )}
-            onClick={onMenuClick}
-          >
-            <Menu className="h-5 w-5 text-primary drop-shadow-sm" />
-          </Button>
+          {settings.collapsibleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "lg:hidden h-12 w-12",
+                "bg-gradient-to-br from-primary/15 via-primary/10 to-primary/5",
+                "hover:from-primary/25 hover:via-primary/15 hover:to-primary/10",
+                "border border-primary/20 hover:border-primary/40",
+                "shadow-xl shadow-primary/20 hover:shadow-2xl hover:shadow-primary/30",
+                "hover:scale-110 active:scale-95",
+                "backdrop-blur-xl",
+                "before:absolute before:inset-0 before:bg-gradient-to-br before:from-white/20 before:to-transparent before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300",
+                buttonClass,
+                animationClass
+              )}
+              onClick={onMenuClick}
+            >
+              <Menu className="h-5 w-5 text-primary drop-shadow-sm" />
+            </Button>
+          )}
         </div>
 
         {/* Center Section - Enhanced Search */}

--- a/components/layout/elegant-layout.tsx
+++ b/components/layout/elegant-layout.tsx
@@ -109,7 +109,11 @@ export function ElegantLayout({
       <ElegantHeader onMenuClick={() => onSidebarOpenChange(true)} />
 
       {/* Sidebar - Lower z-index than header */}
-      <ElegantSidebar open={sidebarOpen} onOpenChange={onSidebarOpenChange} />
+      <ElegantSidebar
+        open={sidebarOpen}
+        onOpenChange={onSidebarOpenChange}
+        collapsible={settings.collapsibleSidebar}
+      />
 
       {/* Main Content - Enhanced with better spacing and animations */}
         <main
@@ -150,7 +154,7 @@ export function ElegantLayout({
         {settings.showFooter && <Footer />}
 
         {/* Mobile overlay with enhanced blur and gradient */}
-        {sidebarOpen && (
+        {sidebarOpen && settings.collapsibleSidebar && (
         <div
           className={cn(
             "fixed inset-0 z-30 lg:hidden",

--- a/components/layout/elegant-layout.tsx
+++ b/components/layout/elegant-layout.tsx
@@ -6,6 +6,7 @@ import { ElegantHeader } from "@/components/layout/elegant-header";
 import { useI18n } from "@/providers/i18n-provider";
 import { useSettings } from "@/providers/settings-provider";
 import { cn } from "@/lib/utils";
+import { Footer } from "@/components/layout/footer";
 
 interface ElegantLayoutProps {
   children: React.ReactNode;
@@ -111,11 +112,11 @@ export function ElegantLayout({
       <ElegantSidebar open={sidebarOpen} onOpenChange={onSidebarOpenChange} />
 
       {/* Main Content - Enhanced with better spacing and animations */}
-      <main
-        className={cn(
-          "relative",
-          getAnimationClass(),
-          settings.stickyHeader ? "pt-20" : "pt-4",
+        <main
+          className={cn(
+            "relative",
+            getAnimationClass(),
+            settings.stickyHeader ? "pt-20" : "pt-4",
           // Desktop margins
           direction === "rtl" ? "lg:mr-80 xl:mr-72" : "lg:ml-80 xl:ml-72",
           // Mobile - no margins when sidebar is closed
@@ -145,10 +146,11 @@ export function ElegantLayout({
             {children}
           </div>
         </div>
-      </main>
+        </main>
+        {settings.showFooter && <Footer />}
 
-      {/* Mobile overlay with enhanced blur and gradient */}
-      {sidebarOpen && (
+        {/* Mobile overlay with enhanced blur and gradient */}
+        {sidebarOpen && (
         <div
           className={cn(
             "fixed inset-0 z-30 lg:hidden",

--- a/components/layout/elegant-sidebar.tsx
+++ b/components/layout/elegant-sidebar.tsx
@@ -26,9 +26,14 @@ import { Logo } from "@/components/ui/logo";
 interface ElegantSidebarProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  collapsible?: boolean;
 }
 
-export function ElegantSidebar({ open, onOpenChange }: ElegantSidebarProps) {
+export function ElegantSidebar({
+  open,
+  onOpenChange,
+  collapsible = true,
+}: ElegantSidebarProps) {
   const pathname = usePathname();
   const { t, direction } = useI18n();
   const { user } = useAuth();
@@ -233,7 +238,7 @@ export function ElegantSidebar({ open, onOpenChange }: ElegantSidebarProps) {
           "before:absolute before:inset-0 before:bg-gradient-to-r before:from-white/10 before:to-white/5 before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300"
         )}
         style={{ paddingLeft: `${16 + indent}px` }}
-        onClick={() => !item.disabled && onOpenChange(false)}
+          onClick={() => !item.disabled && collapsible && onOpenChange(false)}
       >
         <div className="flex items-center space-x-3 rtl:space-x-reverse relative z-10">
           <div
@@ -327,21 +332,23 @@ export function ElegantSidebar({ open, onOpenChange }: ElegantSidebarProps) {
           </div>
 
           {/* Close button for mobile */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "lg:hidden absolute top-3 right-3 h-8 w-8 z-50",
-              "bg-muted/60 hover:bg-primary/10",
-              "border border-border/40 hover:border-primary/30",
-              getButtonStyleClass(),
-              getAnimationClass(),
-              "mt-12"
-            )}
-            onClick={() => onOpenChange(false)}
-          >
-            <X className="w-4 h-4" />
-          </Button>
+          {collapsible && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "lg:hidden absolute top-3 right-3 h-8 w-8 z-50",
+                "bg-muted/60 hover:bg-primary/10",
+                "border border-border/40 hover:border-primary/30",
+                getButtonStyleClass(),
+                getAnimationClass(),
+                "mt-12"
+              )}
+              onClick={() => onOpenChange(false)}
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          )}
 
           {/* Compact User Info */}
           {user && (

--- a/components/layout/floating-header.tsx
+++ b/components/layout/floating-header.tsx
@@ -8,6 +8,7 @@ import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown";
 import { cn } from "@/lib/utils";
 import { Logo } from "@/components/ui/logo";
 import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common";
+import { useSettings } from "@/providers/settings-provider";
 
 interface FloatingHeaderProps {
   onMenuClick: () => void;
@@ -15,6 +16,7 @@ interface FloatingHeaderProps {
 
 export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
   const { t } = useI18n();
+  const settings = useSettings();
   const {
     getHeaderStyleClass,
     getAnimationClass,
@@ -52,19 +54,21 @@ export function FloatingHeader({ onMenuClick }: FloatingHeaderProps) {
         {/* Left Section */}
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
           {/* Mobile Menu Button */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "lg:hidden h-10 w-10 hover:bg-primary/10 hover:text-primary",
-              "shadow-md hover:shadow-lg hover:scale-105",
-              buttonClass,
-              animationClass
-            )}
-            onClick={onMenuClick}
-          >
-            <Menu className="h-5 w-5" />
-          </Button>
+          {settings.collapsibleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "lg:hidden h-10 w-10 hover:bg-primary/10 hover:text-primary",
+                "shadow-md hover:shadow-lg hover:scale-105",
+                buttonClass,
+                animationClass
+              )}
+              onClick={onMenuClick}
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+          )}
 
           {/* Logo/Title - Keep this for floating layout */}
           <div className="flex items-center space-x-3 rtl:space-x-reverse">

--- a/components/layout/floating-layout.tsx
+++ b/components/layout/floating-layout.tsx
@@ -6,6 +6,7 @@ import { FloatingHeader } from "@/components/layout/floating-header";
 import { useI18n } from "@/providers/i18n-provider";
 import { useSettings } from "@/providers/settings-provider";
 import { cn } from "@/lib/utils";
+import { Footer } from "@/components/layout/footer";
 
 interface FloatingLayoutProps {
   children: React.ReactNode;
@@ -87,13 +88,13 @@ export function FloatingLayout({
       />
 
       {/* Main Content */}
-      <main
-        className={cn(
-          "relative z-10",
-          settings.stickyHeader ? "pt-24" : "pt-8",
-          getSpacingClass()
-        )}
-      >
+        <main
+          className={cn(
+            "relative z-10",
+            settings.stickyHeader ? "pt-24" : "pt-8",
+            getSpacingClass()
+          )}
+        >
         <div className="max-w-7xl mx-auto">
           <div
             className={cn(
@@ -115,14 +116,15 @@ export function FloatingLayout({
             {children}
           </div>
         </div>
-      </main>
+        </main>
+        {settings.showFooter && <Footer />}
 
-      {/* Mobile overlay */}
-      {sidebarOpen && (
-        <div
-          className={cn(
-            "fixed inset-0 bg-black/20 backdrop-blur-sm z-30 lg:hidden",
-            getAnimationClass()
+        {/* Mobile overlay */}
+        {sidebarOpen && (
+          <div
+            className={cn(
+              "fixed inset-0 bg-black/20 backdrop-blur-sm z-30 lg:hidden",
+              getAnimationClass()
           )}
           onClick={() => onSidebarOpenChange(false)}
         />

--- a/components/layout/floating-layout.tsx
+++ b/components/layout/floating-layout.tsx
@@ -85,6 +85,7 @@ export function FloatingLayout({
       <FloatingNavigation
         open={sidebarOpen}
         onOpenChange={onSidebarOpenChange}
+        collapsible={settings.collapsibleSidebar}
       />
 
       {/* Main Content */}
@@ -120,7 +121,7 @@ export function FloatingLayout({
         {settings.showFooter && <Footer />}
 
         {/* Mobile overlay */}
-        {sidebarOpen && (
+        {sidebarOpen && settings.collapsibleSidebar && (
           <div
             className={cn(
               "fixed inset-0 bg-black/20 backdrop-blur-sm z-30 lg:hidden",

--- a/components/layout/floating-navigation.tsx
+++ b/components/layout/floating-navigation.tsx
@@ -27,11 +27,13 @@ import { Logo } from "@/components/ui/logo";
 interface FloatingNavigationProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  collapsible?: boolean;
 }
 
 export function FloatingNavigation({
   open,
   onOpenChange,
+  collapsible = true,
 }: FloatingNavigationProps) {
   const pathname = usePathname();
   const { t, direction } = useI18n();
@@ -193,7 +195,7 @@ export function FloatingNavigation({
             : "bg-background/60 text-foreground/80 hover:bg-gradient-to-r hover:from-primary/10 hover:to-primary/5 hover:text-primary hover:shadow-sm"
         )}
         style={{ paddingLeft: `${16 + indent}px` }}
-        onClick={() => !item.disabled && onOpenChange(false)}
+        onClick={() => !item.disabled && collapsible && onOpenChange(false)}
       >
         <div className="flex items-center space-x-3 rtl:space-x-reverse">
           <div
@@ -272,19 +274,21 @@ export function FloatingNavigation({
                 </p>
               </div>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "lg:hidden h-8 w-8 hover:bg-primary/10",
-                "shadow-sm hover:shadow-md hover:scale-105",
-                getButtonStyleClass(),
-                getAnimationClass()
-              )}
-              onClick={() => onOpenChange(false)}
-            >
-              <X className="h-4 w-4" />
-            </Button>
+            {collapsible && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "lg:hidden h-8 w-8 hover:bg-primary/10",
+                  "shadow-sm hover:shadow-md hover:scale-105",
+                  getButtonStyleClass(),
+                  getAnimationClass()
+                )}
+                onClick={() => onOpenChange(false)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
           </div>
 
           {/* User Info */}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useI18n } from "@/providers/i18n-provider";
+
+export function Footer() {
+  const { t } = useI18n();
+  return (
+    <footer className="border-t border-border py-4 text-center text-sm text-muted-foreground">
+      {t("app.version")}
+    </footer>
+  );
+}
+

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { Menu } from "lucide-react"
+import { Bell, Menu } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useI18n } from "@/providers/i18n-provider"
+import { useSettings } from "@/providers/settings-provider"
 import { cn } from "@/lib/utils"
 import { LanguageSwitcher, ThemeSwitcher, HeaderSearch } from "./common"
 import { UserProfileDropdown } from "@/components/ui/user-profile-dropdown"
+import { PageBreadcrumbs } from "@/components/ui/page-breadcrumbs"
 
 interface HeaderProps {
   onMenuClick: () => void
@@ -14,10 +16,22 @@ interface HeaderProps {
 
 export function Header({ onMenuClick, isModern = false }: HeaderProps) {
   const { t } = useI18n()
+  const settings = useSettings()
 
   return (
-    <header className={cn("sticky top-0 z-40 glass border-b border-border", isModern && "h-20 flex items-center")}> 
-      <div className={cn("flex items-center justify-between px-6", isModern ? "py-6" : "py-4")}> 
+    <header
+      className={cn(
+        settings.stickyHeader ? "sticky top-0" : "relative",
+        "z-40 glass border-b border-border",
+        isModern && "h-20 flex flex-col"
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-center justify-between px-6",
+          isModern ? "py-6" : "py-4"
+        )}
+      >
         {/* Left side */}
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
           <Button
@@ -44,9 +58,19 @@ export function Header({ onMenuClick, isModern = false }: HeaderProps) {
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
           <LanguageSwitcher buttonClassName="hover-lift" />
           <ThemeSwitcher buttonClassName="hover-lift" />
+          {settings.showNotifications && (
+            <Button variant="ghost" size="icon" className="hover-lift">
+              <Bell className="w-5 h-5" />
+            </Button>
+          )}
           <UserProfileDropdown showName={false} />
         </div>
       </div>
+      {settings.showBreadcrumbs && (
+        <div className="px-6 pb-2 hidden md:block">
+          <PageBreadcrumbs />
+        </div>
+      )}
     </header>
   )
 }

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -34,14 +34,16 @@ export function Header({ onMenuClick, isModern = false }: HeaderProps) {
       >
         {/* Left side */}
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="lg:hidden hover-lift sidebar-trigger"
-            onClick={onMenuClick}
-          >
-            <Menu className="w-5 h-5" />
-          </Button>
+          {settings.collapsibleSidebar && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="lg:hidden hover-lift sidebar-trigger"
+              onClick={onMenuClick}
+            >
+              <Menu className="w-5 h-5" />
+            </Button>
+          )}
 
           <HeaderSearch
             containerClassName="hidden md:block"

--- a/components/layout/modern-sidebar.tsx
+++ b/components/layout/modern-sidebar.tsx
@@ -26,12 +26,14 @@ interface ModernSidebarProps {
  open: boolean;
  onOpenChange: (open: boolean) => void;
  onHoverChange: (hovered: boolean) => void;
+ collapsible?: boolean;
 }
 
 export function ModernSidebar({
  open,
  onOpenChange,
  onHoverChange,
+ collapsible = true,
 }: ModernSidebarProps) {
  const pathname = usePathname();
  const { t, direction } = useI18n();
@@ -182,7 +184,7 @@ export function ModernSidebar({
            : "justify-center px-2 py-3"
        )}
        style={isHovered ? { paddingLeft: `${12 + indent}px` } : undefined}
-       onClick={() => !item.disabled && onOpenChange(false)}
+       onClick={() => !item.disabled && collapsible && onOpenChange(false)}
      >
        {/* Icon - always visible */}
        <div
@@ -284,17 +286,19 @@ export function ModernSidebar({
              )}
            </div>
 
-           <Button
-             variant="ghost"
-             size="icon"
-             className={cn(
-               "lg:hidden text-sidebar-foreground hover:bg-sidebar-accent flex-shrink-0",
-               "rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:scale-105"
-             )}
-             onClick={() => onOpenChange(false)}
-           >
-             <X className="w-5 h-5" />
-           </Button>
+           {collapsible && (
+             <Button
+               variant="ghost"
+               size="icon"
+               className={cn(
+                 "lg:hidden text-sidebar-foreground hover:bg-sidebar-accent flex-shrink-0",
+                 "rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:scale-105"
+               )}
+               onClick={() => onOpenChange(false)}
+             >
+               <X className="w-5 h-5" />
+             </Button>
+           )}
          </div>
 
          {/* User Info */}

--- a/components/layout/navigation-layout.tsx
+++ b/components/layout/navigation-layout.tsx
@@ -9,6 +9,7 @@ import { useI18n } from "@/providers/i18n-provider";
 import { useSettings } from "@/providers/settings-provider";
 import { navigation } from "@/config/navigation";
 import { cn } from "@/lib/utils";
+import { Footer } from "@/components/layout/footer";
 
 interface NavigationLayoutProps {
   children: React.ReactNode;
@@ -267,6 +268,7 @@ export function NavigationLayout({
             </div>
           </div>
         </main>
+        {settings.showFooter && <Footer />}
       </div>
 
       {/* Mobile Overlay */}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -48,6 +48,21 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       let radiusClasses = "";
 
       switch (settings.buttonStyle) {
+        case "small-round":
+          radiusClasses = "rounded";
+          break;
+        case "medium-round":
+          radiusClasses = "rounded-lg";
+          break;
+        case "large-round":
+          radiusClasses = "rounded-xl";
+          break;
+        case "extra-round":
+          radiusClasses = "rounded-2xl";
+          break;
+        case "super-round":
+          radiusClasses = "rounded-3xl";
+          break;
         case "rounded":
           radiusClasses = "rounded-full";
           break;

--- a/components/ui/logo.tsx
+++ b/components/ui/logo.tsx
@@ -14,6 +14,10 @@ interface LogoProps {
 export function Logo({ className, showText = true }: LogoProps) {
   const settings = useSettings()
 
+  if (!settings.showLogo) {
+    return null
+  }
+
   const sizeClasses = {
     xs: 'h-4 w-4',
     sm: 'h-5 w-5', 
@@ -53,7 +57,7 @@ export function Logo({ className, showText = true }: LogoProps) {
         return (
           <div className={cn(sizeClasses[settings.logoSize], 'relative')}>
             <Image
-              src={settings.logoImagePath || '/placeholder.svg?height=32&width=32'}
+              src={'/app-logo.png'}
               alt="Logo"
               fill
               className={cn('object-contain', animationClasses[settings.logoAnimation])}
@@ -65,15 +69,7 @@ export function Logo({ className, showText = true }: LogoProps) {
           </div>
         )
       case 'custom':
-        return (
-          <div className={cn(
-            textSizeClasses[settings.logoSize],
-            animationClasses[settings.logoAnimation],
-            'font-bold'
-          )}>
-            {settings.logoText || 'SA'}
-          </div>
-        )
+        return null
       default:
         return <Sparkles className={iconClass} />
     }
@@ -82,11 +78,8 @@ export function Logo({ className, showText = true }: LogoProps) {
   return (
     <div className={cn('flex items-center gap-2', className)}>
       {renderIcon()}
-      {showText && settings.logoType !== 'custom' && (
-        <span className={cn(
-          'font-semibold',
-          textSizeClasses[settings.logoSize]
-        )}>
+      {showText && settings.logoType === 'custom' && (
+        <span className={cn('font-semibold', textSizeClasses[settings.logoSize])}>
           {settings.logoText}
         </span>
       )}

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -4,38 +4,50 @@ import { cva } from "class-variance-authority"
 import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { useSettings } from "@/providers/settings-provider"
 
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <NavigationMenuPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative z-10 flex max-w-max flex-1 items-center justify-center",
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <NavigationMenuViewport />
-  </NavigationMenuPrimitive.Root>
-))
+>(({ className, children, ...props }, ref) => {
+  const { navigationStyle } = useSettings()
+
+  return (
+    <NavigationMenuPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative z-10 flex max-w-max flex-1 items-center justify-center",
+        navigationStyle === "sidebar" && "flex-col",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <NavigationMenuViewport />
+    </NavigationMenuPrimitive.Root>
+  )
+})
 NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
 
 const NavigationMenuList = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
->(({ className, ...props }, ref) => (
-  <NavigationMenuPrimitive.List
-    ref={ref}
-    className={cn(
-      "group flex flex-1 list-none items-center justify-center space-x-1",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, ...props }, ref) => {
+  const { navigationStyle } = useSettings()
+
+  return (
+    <NavigationMenuPrimitive.List
+      ref={ref}
+      className={cn(
+        "group flex flex-1 list-none items-center justify-center space-x-1",
+        navigationStyle === "sidebar" &&
+          "flex-col items-stretch space-x-0 space-y-1",
+        className
+      )}
+      {...props}
+    />
+  )
+})
 NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 
 const NavigationMenuItem = NavigationMenuPrimitive.Item
@@ -47,19 +59,31 @@ const navigationMenuTriggerStyle = cva(
 const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <NavigationMenuPrimitive.Trigger
-    ref={ref}
-    className={cn(navigationMenuTriggerStyle(), "group", className)}
-    {...props}
-  >
-    {children}{" "}
-    <ChevronDown
-      className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
-      aria-hidden="true"
-    />
-  </NavigationMenuPrimitive.Trigger>
-))
+>(({ className, children, ...props }, ref) => {
+  const { navigationStyle } = useSettings()
+
+  return (
+    <NavigationMenuPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        navigationMenuTriggerStyle(),
+        "group",
+        navigationStyle === "pills" && "rounded-full bg-muted/50",
+        navigationStyle === "underline" &&
+          "rounded-none border-b-2 border-transparent data-[state=open]:border-primary",
+        navigationStyle === "sidebar" && "w-full justify-start",
+        className
+      )}
+      {...props}
+    >
+      {children}{" "}
+      <ChevronDown
+        className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
+    </NavigationMenuPrimitive.Trigger>
+  )
+})
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName
 
 const NavigationMenuContent = React.forwardRef<

--- a/components/ui/page-breadcrumbs.tsx
+++ b/components/ui/page-breadcrumbs.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+export function PageBreadcrumbs() {
+  const pathname = usePathname();
+  const segments = pathname.split("/").filter(Boolean);
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <Link href="/">Home</Link>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        {segments.map((segment, idx) => {
+          const href = "/" + segments.slice(0, idx + 1).join("/");
+          const label = decodeURIComponent(segment);
+          const isLast = idx === segments.length - 1;
+          return (
+            <React.Fragment key={href}>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {isLast ? (
+                  <BreadcrumbPage>{label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink asChild>
+                    <Link href={href}>{label}</Link>
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+            </React.Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+

--- a/components/ui/user-profile-dropdown.tsx
+++ b/components/ui/user-profile-dropdown.tsx
@@ -15,6 +15,7 @@ import { ChevronDown, Settings, User, LogOut } from "lucide-react";
 import { useAuth } from "@/providers/auth-provider";
 import { useI18n } from "@/providers/i18n-provider";
 import { cn } from "@/lib/utils";
+import { useSettings } from "@/providers/settings-provider";
 
 interface UserProfileDropdownProps {
   variant?:
@@ -37,8 +38,9 @@ export function UserProfileDropdown({
   const { t } = useI18n();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+  const settings = useSettings();
 
-  if (!user) return null;
+  if (!user || !settings.showUserAvatar) return null;
 
   const getInitials = () => {
     // Safe handling of user name

--- a/components/views/settings-view.tsx
+++ b/components/views/settings-view.tsx
@@ -2066,38 +2066,31 @@ export function SettingsView() {
                     <Separator />
 
                     {/* Logo Text */}
-                    <div className="space-y-3">
-                      <Label className="text-sm font-semibold">Logo Text</Label>
-                      <Input
-                        value={settings.logoText}
-                        onChange={(e) => settings.setLogoText(e.target.value)}
-                        placeholder="Enter logo text..."
-                        className="max-w-xs"
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Text displayed next to the logo icon or as custom logo
-                      </p>
-                    </div>
-
-                    <Separator />
-
-                    {/* Logo Image Path */}
-                    {settings.logoType === "image" && (
+                    {settings.logoType === "custom" && (
                       <>
                         <div className="space-y-3">
                           <Label className="text-sm font-semibold">
-                            Logo Image Path
+                            Logo Text
                           </Label>
                           <Input
-                            value={settings.logoImagePath}
-                            onChange={(e) =>
-                              settings.setLogoImagePath(e.target.value)
-                            }
-                            placeholder="/path/to/your/logo.png"
+                            value={settings.logoText}
+                            onChange={(e) => settings.setLogoText(e.target.value)}
+                            placeholder="Enter logo text..."
                             className="max-w-xs"
                           />
                           <p className="text-xs text-muted-foreground">
-                            Path to your custom logo image file
+                            Text displayed as the logo
+                          </p>
+                        </div>
+                        <Separator />
+                      </>
+                    )}
+
+                    {settings.logoType === "image" && (
+                      <>
+                        <div className="space-y-3">
+                          <p className="text-sm text-muted-foreground">
+                            The image logo uses the file at /app-logo.png
                           </p>
                         </div>
                         <Separator />

--- a/providers/settings-provider.tsx
+++ b/providers/settings-provider.tsx
@@ -56,7 +56,16 @@ export type SidebarPosition = "left" | "right";
 // New setting types
 export type HeaderStyle = "default" | "compact" | "elevated" | "transparent";
 export type SidebarStyle = "default" | "compact" | "floating" | "minimal";
-export type ButtonStyle = "default" | "rounded" | "sharp" | "modern";
+export type ButtonStyle =
+  | "default"
+  | "small-round"
+  | "medium-round"
+  | "large-round"
+  | "extra-round"
+  | "super-round"
+  | "rounded"
+  | "sharp"
+  | "modern";
 export type NavigationStyle = "default" | "pills" | "underline" | "sidebar";
 export type SpacingSize = "compact" | "default" | "comfortable" | "spacious";
 export type IconStyle = "outline" | "filled" | "duotone" | "minimal";
@@ -104,7 +113,6 @@ interface SettingsContextType {
   logoAnimation: LogoAnimation;
   logoSize: LogoSize;
   logoText: string;
-  logoImagePath: string;
 
   // Additional app control settings
   showBreadcrumbs: boolean;
@@ -151,7 +159,6 @@ interface SettingsContextType {
   setLogoAnimation: (animation: LogoAnimation) => void;
   setLogoSize: (size: LogoSize) => void;
   setLogoText: (text: string) => void;
-  setLogoImagePath: (path: string) => void;
   setShowBreadcrumbs: (show: boolean) => void;
   setShowUserAvatar: (show: boolean) => void;
   setShowNotifications: (show: boolean) => void;
@@ -204,7 +211,6 @@ const defaultSettings = {
   logoAnimation: "none" as LogoAnimation,
   logoSize: "md" as LogoSize,
   logoText: "SA",
-  logoImagePath: "/placeholder-logo.png",
   showBreadcrumbs: true,
   showUserAvatar: true,
   showNotifications: true,
@@ -396,7 +402,6 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     setLogoAnimation: (animation) => updateSetting("logoAnimation", animation),
     setLogoSize: (size) => updateSetting("logoSize", size),
     setLogoText: (text) => updateSetting("logoText", text),
-    setLogoImagePath: (path) => updateSetting("logoImagePath", path),
     setShowBreadcrumbs: (show) => updateSetting("showBreadcrumbs", show),
     setShowUserAvatar: (show) => updateSetting("showUserAvatar", show),
     setShowNotifications: (show) => updateSetting("showNotifications", show),


### PR DESCRIPTION
## Summary
- Hook header into settings for sticky header, breadcrumbs, notifications toggle
- Add global footer gated by `showFooter` and wire into all layouts
- Apply reduced-motion, high-contrast, and compact-mode CSS based on settings
- Expand button style options and apply them to the button component
- Respect navigation style choices (pills, underline, sidebar) in the navigation menu
- Remove bundled `app-logo.png` so developers can supply their own asset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689670976218832ea83eb4764deb4ebb