### PR TITLE
Localize settings view components

### DIFF
--- a/components/app_views/settings/charts-tab.tsx
+++ b/components/app_views/settings/charts-tab.tsx
@@ -18,6 +18,7 @@ import {
 
 export function ChartsTab() {
   const { t } = useI18n();
+  const days = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
 
   // Comprehensive sample data for all chart types
   const monthlyRevenueData = [
@@ -47,31 +48,31 @@ export function ChartsTab() {
   ];
 
   const marketShareData = [
-    { name: t("devices.desktop") || "Desktop", value: 400, fill: "#8884d8" },
-    { name: t("devices.mobile") || "Mobile", value: 300, fill: "#82ca9d" },
-    { name: t("devices.tablet") || "Tablet", value: 300, fill: "#ffc658" },
-    { name: t("devices.smarttv") || "Smart TV", value: 200, fill: "#ff7300" },
-    { name: t("devices.other") || "Other", value: 100, fill: "#8dd1e1" },
+    { name: t("settings.devices.desktop"), value: 400, fill: "#8884d8" },
+    { name: t("settings.devices.mobile"), value: 300, fill: "#82ca9d" },
+    { name: t("settings.devices.tablet"), value: 300, fill: "#ffc658" },
+    { name: t("settings.devices.smarttv"), value: 200, fill: "#ff7300" },
+    { name: t("settings.devices.other"), value: 100, fill: "#8dd1e1" },
   ];
 
   const scatterData = [
-    { x: 100, y: 200, z: 20, name: t("products.productA") || "Product A" },
-    { x: 120, y: 100, z: 15, name: t("products.productB") || "Product B" },
-    { x: 170, y: 300, z: 25, name: t("products.productC") || "Product C" },
-    { x: 140, y: 250, z: 18, name: t("products.productD") || "Product D" },
-    { x: 150, y: 400, z: 30, name: t("products.productE") || "Product E" },
-    { x: 110, y: 280, z: 22, name: t("products.productF") || "Product F" },
-    { x: 180, y: 350, z: 28, name: t("products.productG") || "Product G" },
-    { x: 130, y: 180, z: 16, name: t("products.productH") || "Product H" },
+    { x: 100, y: 200, z: 20, name: t("products.productA") },
+    { x: 120, y: 100, z: 15, name: t("products.productB") },
+    { x: 170, y: 300, z: 25, name: t("products.productC") },
+    { x: 140, y: 250, z: 18, name: t("products.productD") },
+    { x: 150, y: 400, z: 30, name: t("products.productE") },
+    { x: 110, y: 280, z: 22, name: t("products.productF") },
+    { x: 180, y: 350, z: 28, name: t("products.productG") },
+    { x: 130, y: 180, z: 16, name: t("products.productH") },
   ];
 
   const bubbleData = [
-    { x: 100, y: 200, z: 200, name: t("campaigns.campaignA") || "Campaign A" },
-    { x: 120, y: 100, z: 260, name: t("campaigns.campaignB") || "Campaign B" },
-    { x: 170, y: 300, z: 400, name: t("campaigns.campaignC") || "Campaign C" },
-    { x: 140, y: 250, z: 280, name: t("campaigns.campaignD") || "Campaign D" },
-    { x: 150, y: 400, z: 500, name: t("campaigns.campaignE") || "Campaign E" },
-    { x: 110, y: 280, z: 200, name: t("campaigns.campaignF") || "Campaign F" },
+    { x: 100, y: 200, z: 200, name: t("campaigns.campaignA") },
+    { x: 120, y: 100, z: 260, name: t("campaigns.campaignB") },
+    { x: 170, y: 300, z: 400, name: t("campaigns.campaignC") },
+    { x: 140, y: 250, z: 280, name: t("campaigns.campaignD") },
+    { x: 150, y: 400, z: 500, name: t("campaigns.campaignE") },
+    { x: 110, y: 280, z: 200, name: t("campaigns.campaignF") },
   ];
 
   const dualAxisData = [
@@ -84,69 +85,135 @@ export function ChartsTab() {
   ];
 
   const performanceData = [
-    { subject: "Performance", teamA: 120, teamB: 110, teamC: 95, teamD: 105, fullMark: 150 },
-    { subject: "Quality", teamA: 98, teamB: 130, teamC: 115, teamD: 125, fullMark: 150 },
-    { subject: "Efficiency", teamA: 86, teamB: 130, teamC: 140, teamD: 120, fullMark: 150 },
-    { subject: "Reliability", teamA: 99, teamB: 100, teamC: 110, teamD: 95, fullMark: 150 },
-    { subject: "Innovation", teamA: 85, teamB: 90, teamC: 75, teamD: 100, fullMark: 150 },
-    { subject: "Support", teamA: 65, teamB: 85, teamC: 90, teamD: 80, fullMark: 150 },
-    { subject: "Security", teamA: 110, teamB: 95, teamC: 105, teamD: 115, fullMark: 150 },
-    { subject: "Scalability", teamA: 75, teamB: 120, teamC: 100, teamD: 90, fullMark: 150 },
+    { subject: t("charts.radarSubjects.performance"), teamA: 120, teamB: 110, teamC: 95, teamD: 105, fullMark: 150 },
+    { subject: t("charts.radarSubjects.quality"), teamA: 98, teamB: 130, teamC: 115, teamD: 125, fullMark: 150 },
+    { subject: t("charts.radarSubjects.efficiency"), teamA: 86, teamB: 130, teamC: 140, teamD: 120, fullMark: 150 },
+    { subject: t("charts.radarSubjects.reliability"), teamA: 99, teamB: 100, teamC: 110, teamD: 95, fullMark: 150 },
+    { subject: t("charts.radarSubjects.innovation"), teamA: 85, teamB: 90, teamC: 75, teamD: 100, fullMark: 150 },
+    { subject: t("charts.radarSubjects.support"), teamA: 65, teamB: 85, teamC: 90, teamD: 80, fullMark: 150 },
+    { subject: t("charts.radarSubjects.security"), teamA: 110, teamB: 95, teamC: 105, teamD: 115, fullMark: 150 },
+    { subject: t("charts.radarSubjects.scalability"), teamA: 75, teamB: 120, teamC: 100, teamD: 90, fullMark: 150 },
   ];
 
   // Enhanced heatmap data with better examples
-  const heatmapData1 = Array.from({ length: 52 }, (_, week) => 
+  const heatmapData1 = Array.from({ length: 52 }, (_, week) =>
     Array.from({ length: 7 }, (_, day) => ({
       x: day,
       y: week,
       value: Math.floor(Math.random() * 100) + 1,
-      label: `Week ${week + 1}, ${['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][day]}: Activity Level`
+      label: t("charts.heatmap.weekDayActivity", {
+        week: week + 1,
+        day: t(`daysFull.${days[day]}`)
+      })
     }))
   ).flat();
 
-  const heatmapData2 = Array.from({ length: 12 }, (_, month) => 
+  const heatmapData2 = Array.from({ length: 12 }, (_, month) =>
     Array.from({ length: 31 }, (_, day) => ({
       x: day,
       y: month,
       value: Math.floor(Math.random() * 50) + 10,
-      label: `${t(`months.${['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][month]}`)} ${day + 1}: Sales`
+      label: t("charts.heatmap.monthDaySales", {
+        month: t(`months.${['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'][month]}`),
+        day: day + 1
+      })
     }))
   ).flat();
 
   const hierarchicalData = [
-    { name: t("departments.technology") || "Technology", size: 400, children: [
-      { name: "Frontend", size: 200 },
-      { name: "Backend", size: 150 },
-      { name: "DevOps", size: 50 }
-    ]},
-    { name: t("departments.marketing") || "Marketing", size: 300, children: [
-      { name: "Digital", size: 180 },
-      { name: "Content", size: 120 }
-    ]},
-    { name: t("departments.sales") || "Sales", size: 300, children: [
-      { name: "Enterprise", size: 200 },
-      { name: "SMB", size: 100 }
-    ]},
-    { name: t("departments.support") || "Support", size: 200 },
-    { name: t("departments.operations") || "Operations", size: 150 },
+    {
+      name: t("departments.technology"),
+      size: 400,
+      children: [
+        { name: t("departments.frontend"), size: 200 },
+        { name: t("departments.backend"), size: 150 },
+        { name: t("departments.devops"), size: 50 }
+      ]
+    },
+    {
+      name: t("departments.marketing"),
+      size: 300,
+      children: [
+        { name: t("departments.digital"), size: 180 },
+        { name: t("departments.content"), size: 120 }
+      ]
+    },
+    {
+      name: t("departments.sales"),
+      size: 300,
+      children: [
+        { name: t("departments.enterprise"), size: 200 },
+        { name: t("departments.smb"), size: 100 }
+      ]
+    },
+    { name: t("departments.support"), size: 200 },
+    { name: t("departments.operations"), size: 150 },
   ];
 
   const conversionFunnelData = [
-    { stage: "Website Visitors", value: 10000, description: "Total unique visitors to the website" },
-    { stage: "Product Views", value: 8000, description: "Users who viewed at least one product" },
-    { stage: "Add to Cart", value: 6000, description: "Users who added items to their cart" },
-    { stage: "Checkout Started", value: 4000, description: "Users who initiated the checkout process" },
-    { stage: "Payment Info", value: 3200, description: "Users who entered payment information" },
-    { stage: "Purchase Completed", value: 2000, description: "Successfully completed purchases" },
+    {
+      stage: t("charts.conversionFunnel.websiteVisitors.stage"),
+      value: 10000,
+      description: t("charts.conversionFunnel.websiteVisitors.desc"),
+    },
+    {
+      stage: t("charts.conversionFunnel.productViews.stage"),
+      value: 8000,
+      description: t("charts.conversionFunnel.productViews.desc"),
+    },
+    {
+      stage: t("charts.conversionFunnel.addToCart.stage"),
+      value: 6000,
+      description: t("charts.conversionFunnel.addToCart.desc"),
+    },
+    {
+      stage: t("charts.conversionFunnel.checkoutStarted.stage"),
+      value: 4000,
+      description: t("charts.conversionFunnel.checkoutStarted.desc"),
+    },
+    {
+      stage: t("charts.conversionFunnel.paymentInfo.stage"),
+      value: 3200,
+      description: t("charts.conversionFunnel.paymentInfo.desc"),
+    },
+    {
+      stage: t("charts.conversionFunnel.purchaseCompleted.stage"),
+      value: 2000,
+      description: t("charts.conversionFunnel.purchaseCompleted.desc"),
+    },
   ];
 
   const salesFunnelData = [
-    { stage: "Lead Generation", value: 5000, description: "Marketing qualified leads" },
-    { stage: "Initial Contact", value: 3500, description: "Leads contacted by sales team" },
-    { stage: "Needs Assessment", value: 2500, description: "Qualified prospects with identified needs" },
-    { stage: "Proposal Sent", value: 1500, description: "Formal proposals submitted" },
-    { stage: "Negotiation", value: 1200, description: "Active negotiations in progress" },
-    { stage: "Closed Won", value: 800, description: "Successfully closed deals" },
+    {
+      stage: t("charts.salesFunnel.leadGeneration.stage"),
+      value: 5000,
+      description: t("charts.salesFunnel.leadGeneration.desc"),
+    },
+    {
+      stage: t("charts.salesFunnel.initialContact.stage"),
+      value: 3500,
+      description: t("charts.salesFunnel.initialContact.desc"),
+    },
+    {
+      stage: t("charts.salesFunnel.needsAssessment.stage"),
+      value: 2500,
+      description: t("charts.salesFunnel.needsAssessment.desc"),
+    },
+    {
+      stage: t("charts.salesFunnel.proposalSent.stage"),
+      value: 1500,
+      description: t("charts.salesFunnel.proposalSent.desc"),
+    },
+    {
+      stage: t("charts.salesFunnel.negotiation.stage"),
+      value: 1200,
+      description: t("charts.salesFunnel.negotiation.desc"),
+    },
+    {
+      stage: t("charts.salesFunnel.closedWon.stage"),
+      value: 800,
+      description: t("charts.salesFunnel.closedWon.desc"),
+    },
   ];
 
   const profitLossData = [
@@ -178,11 +245,15 @@ export function ChartsTab() {
   const calendarData = Array.from({ length: 365 }, (_, dayIndex) => {
     const date = new Date();
     date.setDate(date.getDate() - (365 - dayIndex));
+    const count = Math.floor(Math.random() * 20);
     return {
-      date: date.toISOString().split('T')[0],
+      date: date.toISOString().split("T")[0],
       value: Math.floor(Math.random() * 5), // 0-4 activity levels
-      count: Math.floor(Math.random() * 20),
-      label: `${date.toLocaleDateString()}: ${Math.floor(Math.random() * 20)} contributions`
+      count,
+      label: t("charts.heatmap.contributions", {
+        date: date.toLocaleDateString(),
+        count,
+      }),
     };
   });
 
@@ -355,15 +426,72 @@ export function ChartsTab() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <TimelineFunnelCharts 
+            <TimelineFunnelCharts
               data={[
-                { task: "Project Planning", status: "completed", date: "2024-01-15", duration: 2, progress: 100, description: "Initial project scope and requirements gathering" },
-                { task: "UI/UX Design", status: "completed", date: "2024-02-01", duration: 3, progress: 100, description: "User interface and experience design phase" },
-                { task: "Frontend Development", status: "in-progress", date: "2024-02-15", duration: 6, progress: 75, description: "React components and user interface implementation" },
-                { task: "Backend Development", status: "in-progress", date: "2024-03-01", duration: 8, progress: 60, description: "API development and database design" },
-                { task: "Integration Testing", status: "pending", date: "2024-04-01", duration: 2, progress: 0, description: "End-to-end system integration testing" },
-                { task: "User Acceptance Testing", status: "pending", date: "2024-04-15", duration: 2, progress: 0, description: "Client testing and feedback collection" },
-                { task: "Deployment", status: "pending", date: "2024-05-01", duration: 1, progress: 0, description: "Production deployment and go-live" }
+                {
+                  task: t("charts.timeline.tasks.projectPlanning"),
+                  status: "completed",
+                  date: "2024-01-15",
+                  duration: 2,
+                  progress: 100,
+                  description: t("charts.timeline.descriptions.projectPlanning"),
+                },
+                {
+                  task: t("charts.timeline.tasks.uiuxDesign"),
+                  status: "completed",
+                  date: "2024-02-01",
+                  duration: 3,
+                  progress: 100,
+                  description: t("charts.timeline.descriptions.uiuxDesign"),
+                },
+                {
+                  task: t("charts.timeline.tasks.frontendDevelopment"),
+                  status: "in-progress",
+                  date: "2024-02-15",
+                  duration: 6,
+                  progress: 75,
+                  description: t(
+                    "charts.timeline.descriptions.frontendDevelopment"
+                  ),
+                },
+                {
+                  task: t("charts.timeline.tasks.backendDevelopment"),
+                  status: "in-progress",
+                  date: "2024-03-01",
+                  duration: 8,
+                  progress: 60,
+                  description: t(
+                    "charts.timeline.descriptions.backendDevelopment"
+                  ),
+                },
+                {
+                  task: t("charts.timeline.tasks.integrationTesting"),
+                  status: "pending",
+                  date: "2024-04-01",
+                  duration: 2,
+                  progress: 0,
+                  description: t(
+                    "charts.timeline.descriptions.integrationTesting"
+                  ),
+                },
+                {
+                  task: t("charts.timeline.tasks.userAcceptance"),
+                  status: "pending",
+                  date: "2024-04-15",
+                  duration: 2,
+                  progress: 0,
+                  description: t(
+                    "charts.timeline.descriptions.userAcceptance"
+                  ),
+                },
+                {
+                  task: t("charts.timeline.tasks.deployment"),
+                  status: "pending",
+                  date: "2024-05-01",
+                  duration: 1,
+                  progress: 0,
+                  description: t("charts.timeline.descriptions.deployment"),
+                },
               ]}
               conversionData={conversionFunnelData}
               salesData={salesFunnelData}

--- a/components/app_views/settings/components-tab.tsx
+++ b/components/app_views/settings/components-tab.tsx
@@ -213,26 +213,37 @@ export function ComponentsTab() {
         <table className="w-full text-xs">
           <thead>
             <tr className={cn("font-medium text-muted-foreground", getHeaderClasses())}>
-              <th className="text-left py-1.5 px-2 font-semibold">Name</th>
-              <th className="text-left py-1.5 px-2 font-semibold">Role</th>
-              <th className="text-left py-1.5 px-2 font-semibold">Status</th>
+              <th className="text-left py-1.5 px-2 font-semibold">
+                {t("settings.sampleTable.name")}
+              </th>
+              <th className="text-left py-1.5 px-2 font-semibold">
+                {t("settings.sampleTable.role")}
+              </th>
+              <th className="text-left py-1.5 px-2 font-semibold">
+                {t("settings.sampleTable.status")}
+              </th>
             </tr>
           </thead>
           <tbody>
             {sampleTableData.map((row, index) => (
               <tr key={row.id} className={getRowClasses(index)}>
                 <td className="py-1.5 px-2 font-medium">{row.name}</td>
-                <td className="py-1.5 px-2 text-muted-foreground">{row.role}</td>
+                <td className="py-1.5 px-2 text-muted-foreground">
+                  {t(`settings.sampleTable.roles.${row.role}`)}
+                </td>
                 <td className="py-1.5 px-2">
                   <span
                     className={cn(
                       "px-1.5 py-0.5 rounded text-[10px] font-medium",
-                      row.status === "Active" && "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
-                      row.status === "Pending" && "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300",
-                      row.status === "Inactive" && "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
+                      row.status === "active" &&
+                        "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+                      row.status === "pending" &&
+                        "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300",
+                      row.status === "inactive" &&
+                        "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
                     )}
                   >
-                    {row.status}
+                    {t(`settings.sampleTable.${row.status}`)}
                   </span>
                 </td>
               </tr>

--- a/components/app_views/settings/components-tab.tsx
+++ b/components/app_views/settings/components-tab.tsx
@@ -16,34 +16,69 @@ export function ComponentsTab() {
   const { t } = useI18n();
   const settings = useSettings();
   const [multiSelectDemo, setMultiSelectDemo] = useState<string[]>([]);
-  const [styleSelections, setStyleSelections] = useState<Record<string, string | string[]>>({});
+  const [styleSelections, setStyleSelections] =
+    useState<Record<string, string | string[]>>({});
   const [testModalOpen, setTestModalOpen] = useState<string | null>(null);
-  
+
   const { setModalStyle } = settings;
+
+  const weekDays = [
+    t("daysShort.sun"),
+    t("daysShort.mon"),
+    t("daysShort.tue"),
+    t("daysShort.wed"),
+    t("daysShort.thu"),
+    t("daysShort.fri"),
+    t("daysShort.sat"),
+  ];
+  const sampleMonthLabel = `${t("months.jan")} 2024`;
 
   // Sample data for table preview
   const sampleTableData = [
-    { id: "1", name: "John Doe", role: "Admin", status: "Active" },
-    { id: "2", name: "Jane Smith", role: "User", status: "Pending" },
-    { id: "3", name: "Bob Johnson", role: "Editor", status: "Inactive" },
+    {
+      id: "1",
+      name: t("settings.sampleTable.data.john"),
+      role: "admin",
+      status: "active",
+    },
+    {
+      id: "2",
+      name: t("settings.sampleTable.data.jane"),
+      role: "user",
+      status: "pending",
+    },
+    {
+      id: "3",
+      name: t("settings.sampleTable.data.bob"),
+      role: "editor",
+      status: "inactive",
+    },
   ];
 
   const sampleTableColumns = [
-    { key: "name" as const, label: "Name", sortable: true },
-    { key: "role" as const, label: "Role", sortable: true },
+    { key: "name" as const, label: t("settings.sampleTable.name"), sortable: true },
+    {
+      key: "role" as const,
+      label: t("settings.sampleTable.role"),
+      sortable: true,
+      render: (value: string) => t(`settings.sampleTable.roles.${value}`),
+    },
     {
       key: "status" as const,
-      label: "Status",
+      label: t("settings.sampleTable.status"),
       render: (value: string) => (
         <span
           className={cn(
             "px-2 py-1 rounded-full text-xs font-medium",
-            value === "Active" && "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
-            value === "Pending" && "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300",
-            value === "Inactive" && "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
+            value === "active" &&
+              "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+            value === "pending" &&
+              "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300",
+            value === "inactive" &&
+              "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300"
           )}
         >
-          {value}
+          {t(`settings.sampleTable.${value}`)}
         </span>
       ),
     },
@@ -1077,6 +1112,9 @@ export function ComponentsTab() {
       description: t("settings.modalStyle.options.overlay.description"),
     },
   ];
+  const previewStyleName = modalStyles.find(
+    (s) => s.value === testModalOpen,
+  )?.name;
   return (
     <>
                 {/* Button Styles - UPDATED WITH MORE OPTIONS */}
@@ -1324,12 +1362,15 @@ export function ComponentsTab() {
                             <div className="space-y-2">
                               <div className="flex items-center justify-between text-xs">
                                 <CalendarDays className="h-3 w-3" />
-                                <span>Jan 2024</span>
+                                <span>{sampleMonthLabel}</span>
                                 <ChevronRight className="h-3 w-3" />
                               </div>
                               <div className="grid grid-cols-7 gap-0.5 text-xs">
-                                {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((day, i) => (
-                                  <div key={i} className="h-4 w-4 flex items-center justify-center text-muted-foreground">
+                                {weekDays.map((day, i) => (
+                                  <div
+                                    key={i}
+                                    className="h-4 w-4 flex items-center justify-center text-muted-foreground"
+                                  >
                                     {day}
                                   </div>
                                 ))}
@@ -2240,13 +2281,13 @@ export function ComponentsTab() {
                             onClick={() => setTestModalOpen(style.value)}
                             className="w-full text-xs"
                           >
-                            Test {style.name}
+                            {t("settings.modalStyle.testButton", { style: style.name })}
                           </Button>
                         </div>
                       ))}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      Click "Test" buttons to preview each modal style with sample content
+                      {t("settings.modalStyle.testInstructions")}
                     </div>
                   </CardContent>
                 </Card>
@@ -2255,27 +2296,34 @@ export function ComponentsTab() {
                 <GenericModal
                   open={testModalOpen !== null}
                   onOpenChange={(open) => !open && setTestModalOpen(null)}
-                  title={`${testModalOpen} Modal Style Preview`}
+                  title={t("settings.modalStyle.previewTitle", {
+                    style: previewStyleName || "",
+                  })}
                 >
                   <div className="space-y-4">
                     <div className="text-sm text-muted-foreground">
-                      This is a preview of the <strong>{testModalOpen}</strong> modal style.
+                      {t("settings.modalStyle.previewDescription", {
+                        style: previewStyleName || "",
+                      })}
                     </div>
                     <div className="space-y-3">
                       <div className="p-4 bg-muted/50 rounded-lg">
-                        <h4 className="font-medium mb-2">Sample Content</h4>
+                        <h4 className="font-medium mb-2">
+                          {t("settings.modalStyle.sampleContentTitle")}
+                        </h4>
                         <p className="text-sm text-muted-foreground">
-                          This modal demonstrates the visual appearance and behavior of the {testModalOpen} style.
-                          Notice the unique styling, positioning, and visual effects.
+                          {t("settings.modalStyle.sampleContentDescription", {
+                            style: previewStyleName || "",
+                          })}
                         </p>
                       </div>
                       <div className="flex gap-2">
                         <Button size="sm" onClick={() => setTestModalOpen(null)}>
-                          Close Preview
+                          {t("settings.modalStyle.closePreview")}
                         </Button>
-                        <Button 
-                          variant="outline" 
-                          size="sm" 
+                        <Button
+                          variant="outline"
+                          size="sm"
                           onClick={() => {
                             if (testModalOpen) {
                               setModalStyle(testModalOpen as any);
@@ -2283,7 +2331,7 @@ export function ComponentsTab() {
                             }
                           }}
                         >
-                          Apply This Style
+                          {t("settings.modalStyle.applyStyle")}
                         </Button>
                       </div>
                     </div>

--- a/components/app_views/settings/components-tab.tsx
+++ b/components/app_views/settings/components-tab.tsx
@@ -13,7 +13,7 @@ import { useI18n } from "@/providers/i18n-provider";
 import { cn } from "@/lib/utils";
 
 export function ComponentsTab() {
-  const { t } = useI18n();
+  const { t, language } = useI18n();
   const settings = useSettings();
   const [multiSelectDemo, setMultiSelectDemo] = useState<string[]>([]);
   const [styleSelections, setStyleSelections] =
@@ -31,7 +31,10 @@ export function ComponentsTab() {
     t("daysShort.fri"),
     t("daysShort.sat"),
   ];
-  const sampleMonthLabel = `${t("months.jan")} 2024`;
+  const sampleMonthLabel = t("settings.calendar.sampleLabel", {
+    month: t("months.jan"),
+    year: new Intl.NumberFormat(language).format(2024),
+  });
 
   // Sample data for table preview
   const sampleTableData = [

--- a/components/app_views/settings/preview-panel.tsx
+++ b/components/app_views/settings/preview-panel.tsx
@@ -19,19 +19,19 @@ export function PreviewPanel() {
       {
         id: 1,
         name: t("settings.sampleTable.data.john"),
-        email: "john@example.com",
+        email: t("settings.sampleTable.emails.john"),
         status: "active",
       },
       {
         id: 2,
         name: t("settings.sampleTable.data.jane"),
-        email: "jane@example.com",
+        email: t("settings.sampleTable.emails.jane"),
         status: "inactive",
       },
       {
         id: 3,
         name: t("settings.sampleTable.data.bob"),
-        email: "bob@example.com",
+        email: t("settings.sampleTable.emails.bob"),
         status: "active",
       },
     ];

--- a/components/app_views/settings/preview-panel.tsx
+++ b/components/app_views/settings/preview-panel.tsx
@@ -15,11 +15,26 @@ import { useI18n } from "@/providers/i18n-provider";
 export function PreviewPanel() {
   const { t } = useI18n();
 
-  const sampleTableData = [
-    { id: 1, name: "John Doe", email: "john@example.com", status: "active" },
-    { id: 2, name: "Jane Smith", email: "jane@example.com", status: "inactive" },
-    { id: 3, name: "Bob Johnson", email: "bob@example.com", status: "active" },
-  ];
+    const sampleTableData = [
+      {
+        id: 1,
+        name: t("settings.sampleTable.data.john"),
+        email: "john@example.com",
+        status: "active",
+      },
+      {
+        id: 2,
+        name: t("settings.sampleTable.data.jane"),
+        email: "jane@example.com",
+        status: "inactive",
+      },
+      {
+        id: 3,
+        name: t("settings.sampleTable.data.bob"),
+        email: "bob@example.com",
+        status: "active",
+      },
+    ];
 
   const sampleTableColumns = [
     { key: "name" as const, label: t("settings.sampleTable.name"), sortable: true },

--- a/components/app_views/settings/typography-tab.tsx
+++ b/components/app_views/settings/typography-tab.tsx
@@ -423,53 +423,73 @@ export function TypographyTab() {
               {[
                 {
                   value: "classic",
-                  name: "Classic",
-                  description: "Traditional design with subtle borders",
+                  name: t("settings.toast.designOptions.classic.name"),
+                  description: t(
+                    "settings.toast.designOptions.classic.description"
+                  ),
                 },
                 {
                   value: "minimal",
-                  name: "Minimal",
-                  description: "Clean and simple design",
+                  name: t("settings.toast.designOptions.minimal.name"),
+                  description: t(
+                    "settings.toast.designOptions.minimal.description"
+                  ),
                 },
                 {
                   value: "modern",
-                  name: "Modern",
-                  description: "Contemporary with blur effects",
+                  name: t("settings.toast.designOptions.modern.name"),
+                  description: t(
+                    "settings.toast.designOptions.modern.description"
+                  ),
                 },
                 {
                   value: "gradient",
-                  name: "Gradient",
-                  description: "Colorful gradient backgrounds",
+                  name: t("settings.toast.designOptions.gradient.name"),
+                  description: t(
+                    "settings.toast.designOptions.gradient.description"
+                  ),
                 },
                 {
                   value: "outlined",
-                  name: "Outlined",
-                  description: "Border focused transparent design",
+                  name: t("settings.toast.designOptions.outlined.name"),
+                  description: t(
+                    "settings.toast.designOptions.outlined.description"
+                  ),
                 },
                 {
                   value: "neon",
-                  name: "Neon",
-                  description: "Glowing cyberpunk style with pulsing effects",
+                  name: t("settings.toast.designOptions.neon.name"),
+                  description: t(
+                    "settings.toast.designOptions.neon.description"
+                  ),
                 },
                 {
                   value: "glassmorphism",
-                  name: "Glassmorphism",
-                  description: "Transparent glass effect with backdrop blur",
+                  name: t("settings.toast.designOptions.glassmorphism.name"),
+                  description: t(
+                    "settings.toast.designOptions.glassmorphism.description"
+                  ),
                 },
                 {
                   value: "neumorphism",
-                  name: "Neumorphism",
-                  description: "Soft 3D effect with inset shadows",
+                  name: t("settings.toast.designOptions.neumorphism.name"),
+                  description: t(
+                    "settings.toast.designOptions.neumorphism.description"
+                  ),
                 },
                 {
                   value: "aurora",
-                  name: "Aurora",
-                  description: "Magical gradient animations",
+                  name: t("settings.toast.designOptions.aurora.name"),
+                  description: t(
+                    "settings.toast.designOptions.aurora.description"
+                  ),
                 },
                 {
                   value: "cosmic",
-                  name: "Cosmic",
-                  description: "Space theme with stellar gradients",
+                  name: t("settings.toast.designOptions.cosmic.name"),
+                  description: t(
+                    "settings.toast.designOptions.cosmic.description"
+                  ),
                 },
               ].map((design) => (
                 <div
@@ -496,10 +516,10 @@ export function TypographyTab() {
                       <div className="w-full">
                         <ToastProvider>
                           <Toast variant="success" design={design.value as ToastStyle} className="pointer-events-none text-xs">
-                            <ToastContent 
-                              variant="success" 
-                              title="Success" 
-                              description="Task completed"
+                            <ToastContent
+                              variant="success"
+                              title={t("settings.toast.preview.successTitle")}
+                              description={t("settings.toast.preview.successDesc")}
                               showIcon={true}
                             />
                           </Toast>
@@ -510,10 +530,10 @@ export function TypographyTab() {
                       <div className="w-full">
                         <ToastProvider>
                           <Toast variant="destructive" design={design.value as ToastStyle} className="pointer-events-none text-xs">
-                            <ToastContent 
-                              variant="destructive" 
-                              title="Error" 
-                              description="Something went wrong"
+                            <ToastContent
+                              variant="destructive"
+                              title={t("settings.toast.preview.errorTitle")}
+                              description={t("settings.toast.preview.errorDesc")}
                               showIcon={true}
                             />
                           </Toast>
@@ -608,44 +628,52 @@ export function TypographyTab() {
               <Button
                 variant="default"
                 size="sm"
-                onClick={() => success({
-                  title: "Success Toast",
-                  description: "This is a success toast with the selected design",
-                  design: settings.toastStyle as any,
-                })}
+                onClick={() =>
+                  success({
+                    title: t("settings.toast.testMessages.success.title"),
+                    description: t("settings.toast.testMessages.success.desc"),
+                    design: settings.toastStyle as any,
+                  })
+                }
               >
                 {t("settings.toast.testButtons.success")}
               </Button>
               <Button
                 variant="destructive"
                 size="sm"
-                onClick={() => error({
-                  title: "Error Toast",
-                  description: "This is an error toast with the selected design",
-                  design: settings.toastStyle as any,
-                })}
+                onClick={() =>
+                  error({
+                    title: t("settings.toast.testMessages.error.title"),
+                    description: t("settings.toast.testMessages.error.desc"),
+                    design: settings.toastStyle as any,
+                  })
+                }
               >
                 {t("settings.toast.testButtons.error")}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => warning({
-                  title: "Warning Toast",
-                  description: "This is a warning toast with the selected design",
-                  design: settings.toastStyle as any,
-                })}
+                onClick={() =>
+                  warning({
+                    title: t("settings.toast.testMessages.warning.title"),
+                    description: t("settings.toast.testMessages.warning.desc"),
+                    design: settings.toastStyle as any,
+                  })
+                }
               >
                 {t("settings.toast.testButtons.warning")}
               </Button>
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => info({
-                  title: "Info Toast",
-                  description: "This is an info toast with the selected design",
-                  design: settings.toastStyle as any,
-                })}
+                onClick={() =>
+                  info({
+                    title: t("settings.toast.testMessages.info.title"),
+                    description: t("settings.toast.testMessages.info.desc"),
+                    design: settings.toastStyle as any,
+                  })
+                }
               >
                 {t("settings.toast.testButtons.info")}
               </Button>

--- a/components/charts/timeline-funnel-charts.tsx
+++ b/components/charts/timeline-funnel-charts.tsx
@@ -29,13 +29,14 @@ const generateColor = (index: number) => {
 
 // Enhanced Generic Timeline Component
 const TimelineChart = ({ data, title, showProgress = true }: { data: any[]; title: string; showProgress?: boolean }) => {
+  const { t } = useI18n();
   // Return empty state if no data provided
   if (!data || data.length === 0) {
     return (
       <div className="space-y-4">
         <h4 className="text-sm font-medium">{title}</h4>
         <div className="text-center py-8 text-muted-foreground">
-          <p>No timeline data available</p>
+          <p>{t("charts.timeline.noData")}</p>
         </div>
       </div>
     );
@@ -75,14 +76,22 @@ const TimelineChart = ({ data, title, showProgress = true }: { data: any[]; titl
                 <div className="flex-1 min-w-0">
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
-                      <span className="text-sm font-medium text-foreground">{item.task || item.name || `Task ${index + 1}`}</span>
+                      <span className="text-sm font-medium text-foreground">
+                        {item.task || item.name || t("charts.timeline.defaultTask", { index: index + 1 })}
+                      </span>
                       <div className="text-xs text-muted-foreground mt-1">
-                        {item.date && <span>Date: {item.date}</span>}
-                        {item.duration && <span className="ml-3">Duration: {item.duration} {item.durationUnit || 'weeks'}</span>}
+                        {item.date && (
+                          <span>{t("charts.timeline.date")}: {item.date}</span>
+                        )}
+                        {item.duration && (
+                          <span className="ml-3">
+                            {t("charts.timeline.duration")}: {item.duration} {t(`charts.timeline.${item.durationUnit || 'weeks'}`)}
+                          </span>
+                        )}
                       </div>
                     </div>
                     <span className="text-xs px-2 py-1 rounded-full text-white" style={{ backgroundColor: statusColor }}>
-                      {item.status}
+                      {t(`charts.timeline.statuses.${item.status}`)}
                     </span>
                   </div>
                   
@@ -90,7 +99,7 @@ const TimelineChart = ({ data, title, showProgress = true }: { data: any[]; titl
                   {showProgress && (
                     <div className="mt-2">
                       <div className="flex justify-between text-xs text-muted-foreground mb-1">
-                        <span>Progress</span>
+                        <span>{t("charts.timeline.progress")}</span>
                         <span>{progress}%</span>
                       </div>
                       <div className="w-full bg-gray-200 rounded-full h-2">
@@ -121,19 +130,20 @@ const TimelineChart = ({ data, title, showProgress = true }: { data: any[]; titl
 };
 
 // Enhanced Generic Funnel Component
-const FunnelChart = ({ data, title, showConversion = true, showDropoff = false }: { 
-  data: any[]; 
-  title: string; 
+const FunnelChart = ({ data, title, showConversion = true, showDropoff = false }: {
+  data: any[];
+  title: string;
   showConversion?: boolean;
   showDropoff?: boolean;
 }) => {
+  const { t } = useI18n();
   // Return empty state if no data provided
   if (!data || data.length === 0) {
     return (
       <div className="space-y-4">
         <h4 className="text-sm font-medium">{title}</h4>
         <div className="text-center py-8 text-muted-foreground">
-          <p>No funnel data available</p>
+          <p>{t("charts.funnel.noData")}</p>
         </div>
       </div>
     );
@@ -158,17 +168,19 @@ const FunnelChart = ({ data, title, showConversion = true, showDropoff = false }
           return (
             <div key={index} className="space-y-2">
               <div className="flex justify-between items-center text-sm">
-                <span className="font-medium">{item.stage || item.name || `Stage ${index + 1}`}</span>
+                <span className="font-medium">
+                  {item.stage || item.name || t("charts.funnel.defaultStage", { index: index + 1 })}
+                </span>
                 <div className="text-right">
                   <div className="font-bold">{value.toLocaleString()}</div>
                   {showConversion && (
                     <div className="text-xs text-muted-foreground">
-                      Conversion: {conversionRate}%
+                      {t("charts.funnel.conversion")}: {conversionRate}%
                     </div>
                   )}
                   {showDropoff && index > 0 && (
                     <div className="text-xs text-red-500">
-                      Dropoff: {dropoffCount.toLocaleString()} ({dropoffRate}%)
+                      {t("charts.funnel.dropoff")}: {dropoffCount.toLocaleString()} ({dropoffRate}%)
                     </div>
                   )}
                 </div>
@@ -213,14 +225,14 @@ const FunnelChart = ({ data, title, showConversion = true, showDropoff = false }
       <div className="mt-4 p-3 bg-muted rounded-lg">
         <div className="grid grid-cols-2 gap-4 text-xs">
           <div>
-            <span className="text-muted-foreground">Total Conversion:</span>
+            <span className="text-muted-foreground">{t("charts.funnel.totalConversion")}</span>
             <div className="font-medium">
               {data.length > 0 && maxValue > 0 ? 
                 ((Number(data[data.length - 1]?.value) || 0) / maxValue * 100).toFixed(1) : '0.0'}%
             </div>
           </div>
           <div>
-            <span className="text-muted-foreground">Total Volume:</span>
+            <span className="text-muted-foreground">{t("charts.funnel.totalVolume")}</span>
             <div className="font-medium">{maxValue.toLocaleString()}</div>
           </div>
         </div>
@@ -276,9 +288,9 @@ export function TimelineFunnelCharts({
             <CardDescription>{t("charts.funnel.advanced.description")}</CardDescription>
           </CardHeader>
           <CardContent>
-            <FunnelChart 
-              data={salesData.length > 0 ? salesData : salesFunnelData} 
-              title="Advanced Sales Funnel"
+            <FunnelChart
+              data={salesData.length > 0 ? salesData : salesFunnelData}
+              title={t("charts.funnel.advanced.salesTitle")}
               showConversion={true}
               showDropoff={true}
             />

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -149,11 +149,130 @@ export const ar = {
     marketShare: "حصة السوق",
     conversionRates: "معدلات التحويل",
     trafficSources: "مصادر الزيارات",
-    
+
     // Chart descriptions (removed duplicates)
     // lineDesc, areaDesc, etc. already defined above
     users: "المستخدمون",
     revenue: "الإيرادات",
+
+    radarSubjects: {
+      performance: "الأداء",
+      quality: "الجودة",
+      efficiency: "الكفاءة",
+      reliability: "الموثوقية",
+      innovation: "الابتكار",
+      support: "الدعم",
+      security: "الأمان",
+      scalability: "قابلية التوسع",
+    },
+
+    heatmap: {
+      weekDayActivity: "الأسبوع {week}، {day}: مستوى النشاط",
+      monthDaySales: "{month} {day}: المبيعات",
+      contributions: "{date}: {count} مساهمات",
+    },
+
+    conversionFunnel: {
+      websiteVisitors: {
+        stage: "زوار الموقع",
+        desc: "إجمالي الزوار الفريدين للموقع",
+      },
+      productViews: {
+        stage: "مشاهدات المنتج",
+        desc: "المستخدمون الذين شاهدوا منتجًا واحدًا على الأقل",
+      },
+      addToCart: {
+        stage: "إضافة إلى السلة",
+        desc: "المستخدمون الذين أضافوا عناصر إلى سلتهم",
+      },
+      checkoutStarted: {
+        stage: "بدء الدفع",
+        desc: "المستخدمون الذين بدأوا عملية الدفع",
+      },
+      paymentInfo: {
+        stage: "معلومات الدفع",
+        desc: "المستخدمون الذين أدخلوا معلومات الدفع",
+      },
+      purchaseCompleted: {
+        stage: "إكمال الشراء",
+        desc: "المشتريات المكتملة بنجاح",
+      },
+    },
+
+    salesFunnel: {
+      leadGeneration: {
+        stage: "توليد العملاء المحتملين",
+        desc: "العملاء المحتملون المؤهلون من التسويق",
+      },
+      initialContact: {
+        stage: "الاتصال الأولي",
+        desc: "العملاء المحتملون الذين تم الاتصال بهم من قبل فريق المبيعات",
+      },
+      needsAssessment: {
+        stage: "تقييم الاحتياجات",
+        desc: "العملاء المحتملون المؤهلون مع احتياجات محددة",
+      },
+      proposalSent: {
+        stage: "إرسال العرض",
+        desc: "العروض الرسمية المرسلة",
+      },
+      negotiation: {
+        stage: "التفاوض",
+        desc: "المفاوضات النشطة الجارية",
+      },
+      closedWon: {
+        stage: "صفقات ناجحة",
+        desc: "الصفقات التي تمت بنجاح",
+      },
+    },
+
+    timeline: {
+      noData: "لا توجد بيانات للجدول الزمني",
+      defaultTask: "مهمة {index}",
+      date: "التاريخ",
+      duration: "المدة",
+      weeks: "أسابيع",
+      progress: "التقدم",
+      statuses: {
+        completed: "مكتمل",
+        "in-progress": "جارٍ",
+        pending: "قيد الانتظار",
+        cancelled: "ملغى",
+        "on-hold": "معلق",
+      },
+      tasks: {
+        projectPlanning: "تخطيط المشروع",
+        uiuxDesign: "تصميم واجهة وتجربة المستخدم",
+        frontendDevelopment: "تطوير الواجهة الأمامية",
+        backendDevelopment: "تطوير الخلفية",
+        integrationTesting: "اختبار التكامل",
+        userAcceptance: "اختبار قبول المستخدم",
+        deployment: "النشر",
+      },
+      descriptions: {
+        projectPlanning: "تحديد نطاق المشروع وجمع المتطلبات",
+        uiuxDesign: "مرحلة تصميم واجهة وتجربة المستخدم",
+        frontendDevelopment: "تنفيذ مكونات React وواجهة المستخدم",
+        backendDevelopment: "تطوير واجهات برمجة التطبيقات وتصميم قاعدة البيانات",
+        integrationTesting: "اختبار تكامل النظام من البداية للنهاية",
+        userAcceptance: "اختبار العميل وجمع الملاحظات",
+        deployment: "نشر الإنتاج وتشغيل النظام",
+      },
+    },
+
+    funnel: {
+      noData: "لا توجد بيانات للقمع",
+      defaultStage: "المرحلة {index}",
+      conversion: "التحويل",
+      dropoff: "التسرب",
+      totalConversion: "إجمالي التحويل:",
+      totalVolume: "إجمالي الحجم:",
+      advanced: {
+        title: "قمع متقدم",
+        description: "قمع مبيعات مفصل مع مقاييس التحويل",
+        salesTitle: "قمع المبيعات المتقدم",
+      },
+    },
     
     // Chart tabs
     tabs: {
@@ -321,6 +440,51 @@ export const ar = {
     thu: "خ",
     fri: "ج",
     sat: "س",
+  },
+
+  daysFull: {
+    mon: "الاثنين",
+    tue: "الثلاثاء",
+    wed: "الأربعاء",
+    thu: "الخميس",
+    fri: "الجمعة",
+    sat: "السبت",
+    sun: "الأحد",
+  },
+
+  products: {
+    productA: "المنتج أ",
+    productB: "المنتج ب",
+    productC: "المنتج ج",
+    productD: "المنتج د",
+    productE: "المنتج هـ",
+    productF: "المنتج و",
+    productG: "المنتج ز",
+    productH: "المنتج ح",
+  },
+
+  campaigns: {
+    campaignA: "الحملة أ",
+    campaignB: "الحملة ب",
+    campaignC: "الحملة ج",
+    campaignD: "الحملة د",
+    campaignE: "الحملة هـ",
+    campaignF: "الحملة و",
+  },
+
+  departments: {
+    technology: "التقنية",
+    marketing: "التسويق",
+    sales: "المبيعات",
+    support: "الدعم",
+    operations: "العمليات",
+    frontend: "الواجهة الأمامية",
+    backend: "الواجهة الخلفية",
+    devops: "ديف أوبس",
+    digital: "رقمي",
+    content: "المحتوى",
+    enterprise: "المؤسسات",
+    smb: "الشركات الصغيرة والمتوسطة",
   },
 
   // Users
@@ -720,6 +884,50 @@ export const ar = {
           title: "منشور الماس",
           description: "تصميم منشوري متعدد الألوان مع تدرجات قوس قزح",
         },
+      },
+    },
+    toast: {
+      title: "إشعارات التوست",
+      description: "خصص مظهر وسلوك التوست",
+      designLabel: "التصميم",
+      designOptions: {
+        classic: { name: "كلاسيكي", description: "تصميم تقليدي بحواف خفيفة" },
+        minimal: { name: "بسيط", description: "تصميم نظيف وبسيط" },
+        modern: { name: "حديث", description: "معاصر مع تأثيرات ضبابية" },
+        gradient: { name: "متدرج", description: "خلفيات متدرجة ملونة" },
+        outlined: { name: "محاط", description: "تصميم شفاف يركز على الحدود" },
+        neon: { name: "نيون", description: "نمط سايبربانك متوهج" },
+        glassmorphism: { name: "زجاجي", description: "تأثير زجاجي شفاف مع ضبابية" },
+        neumorphism: { name: "نيومورفيزم", description: "تأثير ثلاثي الأبعاد ناعم" },
+        aurora: { name: "شفق", description: "تدرجات متحركة سحرية" },
+        cosmic: { name: "كوني", description: "سمة فضائية مع تدرجات نجمية" },
+      },
+      preview: {
+        successTitle: "نجاح",
+        successDesc: "تم إكمال المهمة",
+        errorTitle: "خطأ",
+        errorDesc: "حدث خطأ ما",
+      },
+      durationLabel: "المدة",
+      durationOptions: {
+        quick: { name: "سريع", description: "يظهر لمدة ثانية واحدة" },
+        normal: { name: "عادي", description: "يظهر لمدة 3 ثوان" },
+        long: { name: "طويل", description: "يظهر لمدة 5 ثوان" },
+        extended: { name: "ممتد", description: "يظهر لمدة 10 ثوان" },
+      },
+      testLabel: "اختبار التوست",
+      testButtons: {
+        success: "نجاح",
+        error: "خطأ",
+        warning: "تحذير",
+        info: "معلومة",
+      },
+      testHint: "اضغط على الأزرار لمعاينة التصميم المختار",
+      testMessages: {
+        success: { title: "توست النجاح", desc: "هذا توست نجاح مع التصميم المختار" },
+        error: { title: "توست الخطأ", desc: "هذا توست خطأ مع التصميم المختار" },
+        warning: { title: "توست التحذير", desc: "هذا توست تحذير مع التصميم المختار" },
+        info: { title: "توست المعلومات", desc: "هذا توست معلومات مع التصميم المختار" },
       },
     },
     darkMode: "الوضع المظلم",

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -313,6 +313,16 @@ export const ar = {
     dec: "ديسمبر",
   },
 
+  daysShort: {
+    sun: "ح",
+    mon: "ن",
+    tue: "ث",
+    wed: "ر",
+    thu: "خ",
+    fri: "ج",
+    sat: "س",
+  },
+
   // Users
   users: {
     title: "إدارة المستخدمين",
@@ -826,6 +836,18 @@ export const ar = {
       status: "الحالة",
       active: "نشط",
       inactive: "غير نشط",
+      pending: "قيد الانتظار",
+      role: "الدور",
+      roles: {
+        admin: "مسؤول",
+        user: "مستخدم",
+        editor: "محرر",
+      },
+      data: {
+        john: "جون دو",
+        jane: "جين سميث",
+        bob: "بوب جونسون",
+      },
     },
 
     layoutTemplate: {
@@ -1091,6 +1113,16 @@ export const ar = {
         card: { name: "بطاقة", description: "تصميم نظيف على شكل بطاقة" },
         overlay: { name: "تراكب", description: "تراكب كبير مع خلفية" },
       },
+      testButton: "اختبار {{style}}",
+      testInstructions:
+        'انقر أزرار "اختبار" لمعاينة كل نمط حوار مع محتوى تجريبي',
+      previewTitle: "معاينة نمط حوار {{style}}",
+      previewDescription: "هذه معاينة لنمط حوار {{style}}.",
+      sampleContentTitle: "محتوى تجريبي",
+      sampleContentDescription:
+        "يعرض هذا الحوار مظهر وسلوك نمط {{style}}. لاحظ الأسلوب والتنسيق والتأثيرات المختلفة.",
+      closePreview: "إغلاق المعاينة",
+      applyStyle: "تطبيق هذا النمط",
     },
     datePickerStyle: {
       title: "نمط منتقي التاريخ",

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -1354,6 +1354,9 @@ export const ar = {
         elegant: { name: "أنيق", description: "تدرج متطور مع خط مميز" },
       },
     },
+    calendar: {
+      sampleLabel: "{{month}} {{year}}",
+    },
     calendarStyle: {
       title: "نمط التقويم",
       description: "اختر كيفية ظهور قوائم التقويم المنسدلة",

--- a/locales/ar.ts
+++ b/locales/ar.ts
@@ -1056,6 +1056,11 @@ export const ar = {
         jane: "جين سميث",
         bob: "بوب جونسون",
       },
+      emails: {
+        john: "john@example.com",
+        jane: "jane@example.com",
+        bob: "bob@example.com",
+      },
     },
 
     layoutTemplate: {

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1496,6 +1496,9 @@ export const en = {
         },
       },
     },
+    calendar: {
+      sampleLabel: "{{month}} {{year}}",
+    },
     calendarStyle: {
       title: "Calendar Style",
       description: "Choose how calendar dropdowns should appear",

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -211,6 +211,125 @@ export const en = {
     // lineDesc, areaDesc, etc. already defined above
     users: "Users",
     revenue: "Revenue",
+
+    radarSubjects: {
+      performance: "Performance",
+      quality: "Quality",
+      efficiency: "Efficiency",
+      reliability: "Reliability",
+      innovation: "Innovation",
+      support: "Support",
+      security: "Security",
+      scalability: "Scalability",
+    },
+
+    heatmap: {
+      weekDayActivity: "Week {week}, {day}: Activity Level",
+      monthDaySales: "{month} {day}: Sales",
+      contributions: "{date}: {count} contributions",
+    },
+
+    conversionFunnel: {
+      websiteVisitors: {
+        stage: "Website Visitors",
+        desc: "Total unique visitors to the website",
+      },
+      productViews: {
+        stage: "Product Views",
+        desc: "Users who viewed at least one product",
+      },
+      addToCart: {
+        stage: "Add to Cart",
+        desc: "Users who added items to their cart",
+      },
+      checkoutStarted: {
+        stage: "Checkout Started",
+        desc: "Users who initiated the checkout process",
+      },
+      paymentInfo: {
+        stage: "Payment Info",
+        desc: "Users who entered payment information",
+      },
+      purchaseCompleted: {
+        stage: "Purchase Completed",
+        desc: "Successfully completed purchases",
+      },
+    },
+
+    salesFunnel: {
+      leadGeneration: {
+        stage: "Lead Generation",
+        desc: "Marketing qualified leads",
+      },
+      initialContact: {
+        stage: "Initial Contact",
+        desc: "Leads contacted by sales team",
+      },
+      needsAssessment: {
+        stage: "Needs Assessment",
+        desc: "Qualified prospects with identified needs",
+      },
+      proposalSent: {
+        stage: "Proposal Sent",
+        desc: "Formal proposals submitted",
+      },
+      negotiation: {
+        stage: "Negotiation",
+        desc: "Active negotiations in progress",
+      },
+      closedWon: {
+        stage: "Closed Won",
+        desc: "Successfully closed deals",
+      },
+    },
+
+    timeline: {
+      noData: "No timeline data available",
+      defaultTask: "Task {index}",
+      date: "Date",
+      duration: "Duration",
+      weeks: "weeks",
+      progress: "Progress",
+      statuses: {
+        completed: "Completed",
+        "in-progress": "In Progress",
+        pending: "Pending",
+        cancelled: "Cancelled",
+        "on-hold": "On Hold",
+      },
+      tasks: {
+        projectPlanning: "Project Planning",
+        uiuxDesign: "UI/UX Design",
+        frontendDevelopment: "Frontend Development",
+        backendDevelopment: "Backend Development",
+        integrationTesting: "Integration Testing",
+        userAcceptance: "User Acceptance Testing",
+        deployment: "Deployment",
+      },
+      descriptions: {
+        projectPlanning: "Initial project scope and requirements gathering",
+        uiuxDesign: "User interface and experience design phase",
+        frontendDevelopment: "React components and user interface implementation",
+        backendDevelopment: "API development and database design",
+        integrationTesting: "End-to-end system integration testing",
+        userAcceptance: "Client testing and feedback collection",
+        deployment: "Production deployment and go-live",
+      },
+    },
+
+    funnel: {
+      noData: "No funnel data available",
+      defaultStage: "Stage {index}",
+      conversion: "Conversion",
+      dropoff: "Dropoff",
+      totalConversion: "Total Conversion:",
+      totalVolume: "Total Volume:",
+      advanced: {
+        title: "Advanced Funnel",
+        description: "Detailed sales funnel with conversion metrics",
+        salesTitle: "Advanced Sales Funnel",
+      },
+    },
   },
 
   // Months
@@ -237,6 +356,51 @@ export const en = {
     thu: "T",
     fri: "F",
     sat: "S",
+  },
+
+  daysFull: {
+    mon: "Mon",
+    tue: "Tue",
+    wed: "Wed",
+    thu: "Thu",
+    fri: "Fri",
+    sat: "Sat",
+    sun: "Sun",
+  },
+
+  products: {
+    productA: "Product A",
+    productB: "Product B",
+    productC: "Product C",
+    productD: "Product D",
+    productE: "Product E",
+    productF: "Product F",
+    productG: "Product G",
+    productH: "Product H",
+  },
+
+  campaigns: {
+    campaignA: "Campaign A",
+    campaignB: "Campaign B",
+    campaignC: "Campaign C",
+    campaignD: "Campaign D",
+    campaignE: "Campaign E",
+    campaignF: "Campaign F",
+  },
+
+  departments: {
+    technology: "Technology",
+    marketing: "Marketing",
+    sales: "Sales",
+    support: "Support",
+    operations: "Operations",
+    frontend: "Frontend",
+    backend: "Backend",
+    devops: "DevOps",
+    digital: "Digital",
+    content: "Content",
+    enterprise: "Enterprise",
+    smb: "SMB",
   },
 
   // Users
@@ -567,6 +731,92 @@ export const en = {
         diamond: {
           title: "Diamond Prism",
           description: "Multi-colored prismatic design with rainbow gradients",
+        },
+      },
+    },
+    toast: {
+      title: "Toast Notifications",
+      description: "Customize toast appearance and behavior",
+      designLabel: "Design",
+      designOptions: {
+        classic: {
+          name: "Classic",
+          description: "Traditional design with subtle borders",
+        },
+        minimal: {
+          name: "Minimal",
+          description: "Clean and simple design",
+        },
+        modern: {
+          name: "Modern",
+          description: "Contemporary with blur effects",
+        },
+        gradient: {
+          name: "Gradient",
+          description: "Colorful gradient backgrounds",
+        },
+        outlined: {
+          name: "Outlined",
+          description: "Border focused transparent design",
+        },
+        neon: {
+          name: "Neon",
+          description: "Glowing cyberpunk style with pulsing effects",
+        },
+        glassmorphism: {
+          name: "Glassmorphism",
+          description: "Transparent glass effect with backdrop blur",
+        },
+        neumorphism: {
+          name: "Neumorphism",
+          description: "Soft 3D effect with inset shadows",
+        },
+        aurora: {
+          name: "Aurora",
+          description: "Magical gradient animations",
+        },
+        cosmic: {
+          name: "Cosmic",
+          description: "Space theme with stellar gradients",
+        },
+      },
+      preview: {
+        successTitle: "Success",
+        successDesc: "Task completed",
+        errorTitle: "Error",
+        errorDesc: "Something went wrong",
+      },
+      durationLabel: "Duration",
+      durationOptions: {
+        quick: { name: "Quick", description: "Shows for 1 second" },
+        normal: { name: "Normal", description: "Shows for 3 seconds" },
+        long: { name: "Long", description: "Shows for 5 seconds" },
+        extended: { name: "Extended", description: "Shows for 10 seconds" },
+      },
+      testLabel: "Test Toasts",
+      testButtons: {
+        success: "Success",
+        error: "Error",
+        warning: "Warning",
+        info: "Info",
+      },
+      testHint: "Click buttons to preview selected design",
+      testMessages: {
+        success: {
+          title: "Success Toast",
+          desc: "This is a success toast with the selected design",
+        },
+        error: {
+          title: "Error Toast",
+          desc: "This is an error toast with the selected design",
+        },
+        warning: {
+          title: "Warning Toast",
+          desc: "This is a warning toast with the selected design",
+        },
+        info: {
+          title: "Info Toast",
+          desc: "This is an info toast with the selected design",
         },
       },
     },

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -1170,6 +1170,11 @@ export const en = {
         jane: "Jane Smith",
         bob: "Bob Johnson",
       },
+      emails: {
+        john: "john@example.com",
+        jane: "jane@example.com",
+        bob: "bob@example.com",
+      },
     },
 
     layoutTemplate: {

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -229,6 +229,16 @@ export const en = {
     dec: "Dec",
   },
 
+  daysShort: {
+    sun: "S",
+    mon: "M",
+    tue: "T",
+    wed: "W",
+    thu: "T",
+    fri: "F",
+    sat: "S",
+  },
+
   // Users
   users: {
     title: "User Management",
@@ -898,6 +908,18 @@ export const en = {
       status: "Status",
       active: "Active",
       inactive: "Inactive",
+      pending: "Pending",
+      role: "Role",
+      roles: {
+        admin: "Admin",
+        user: "User",
+        editor: "Editor",
+      },
+      data: {
+        john: "John Doe",
+        jane: "Jane Smith",
+        bob: "Bob Johnson",
+      },
     },
 
     layoutTemplate: {
@@ -1173,6 +1195,16 @@ export const en = {
         card: { name: "Card", description: "Clean card-style design" },
         overlay: { name: "Overlay", description: "Large overlay with backdrop" },
       },
+      testButton: "Test {{style}}",
+      testInstructions:
+        'Click "Test" buttons to preview each modal style with sample content',
+      previewTitle: "{{style}} Modal Style Preview",
+      previewDescription: "This is a preview of the {{style}} modal style.",
+      sampleContentTitle: "Sample Content",
+      sampleContentDescription:
+        "This modal demonstrates the visual appearance and behavior of the {{style}} style. Notice the unique styling, positioning, and visual effects.",
+      closePreview: "Close Preview",
+      applyStyle: "Apply This Style",
     },
     datePickerStyle: {
       title: "Date Picker Style",


### PR DESCRIPTION
## Summary
- Localize settings components tab with translated sample data, calendar preview, and modal testing text
- Add translations and sample data localization for preview panel
- Expand English and Arabic locale files with weekday, sample table, and modal style strings

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6cb801300832e8c65e73f2063951d